### PR TITLE
Complete TV layout and gamepad controller support

### DIFF
--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/WhiteAestherAppTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/WhiteAestherAppTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -20,7 +21,6 @@ import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.test.espresso.Espresso.pressBack
-import androidx.test.platform.app.InstrumentationRegistry
 import com.whitedns.whiteaesther.EndpointScannerState
 import com.whitedns.whiteaesther.data.AppSettings
 import com.whitedns.whiteaesther.data.EndpointMode
@@ -30,16 +30,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Assume.assumeTrue
 
 class WhiteAestherAppTest {
     @get:Rule
     val compose = createComposeRule()
-
-    private fun assumeTelevision() {
-        val configuration = InstrumentationRegistry.getInstrumentation().targetContext.resources.configuration
-        assumeTrue(TvUiPolicy.isTelevision(configuration.uiMode))
-    }
 
     private fun setApp(
         initial: AppSettings = AppSettings(),
@@ -129,7 +123,6 @@ class WhiteAestherAppTest {
 
     @Test
     fun tvStartsOnTheConnectionOrbAndCentreConnectsOnce() {
-        assumeTelevision()
         var requests = 0
         setApp(television = true, onConnect = { requests++ })
 
@@ -142,12 +135,12 @@ class WhiteAestherAppTest {
 
     @Test
     fun tvTabSelectionKeepsRemoteFocusOnTheSelectedTab() {
-        assumeTelevision()
         setApp(television = true)
 
-        compose.onNodeWithTag("connect-orb").performKeyInput { pressKey(Key.Tab) }
-        compose.onNodeWithTag("tab-home").assertIsFocused()
-            .performKeyInput { pressKey(Key.DirectionRight) }
+        compose.onNodeWithTag("tab-home")
+            .performSemanticsAction(SemanticsActions.RequestFocus) { it.invoke() }
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.DirectionDown) }
         compose.onNodeWithTag("tab-routes")
             .assertIsFocused()
             .performKeyInput { pressKey(Key.DirectionCenter) }
@@ -164,7 +157,6 @@ class WhiteAestherAppTest {
 
     @Test
     fun tvProfileAndCompositeSwitchActivateFromOneRemoteTarget() {
-        assumeTelevision()
         var writes = 0
         setApp(television = true, onSettings = { writes++ })
         compose.onNodeWithTag("tab-routes").performClick()
@@ -188,7 +180,6 @@ class WhiteAestherAppTest {
 
     @Test
     fun tvBackReturnsToTheOriginatingDetailRow() {
-        assumeTelevision()
         setApp(television = true)
         compose.onNodeWithTag("tab-routes").performClick()
         compose.onNodeWithTag("routes-endpoint")
@@ -204,7 +195,6 @@ class WhiteAestherAppTest {
 
     @Test
     fun tvFocusBringsLongSettingsContentIntoViewAndHidesTileSetup() {
-        assumeTelevision()
         setApp(initial = AppSettings(showAdvanced = true), television = true)
         compose.onNodeWithTag("tab-traffic").performClick()
 
@@ -221,5 +211,45 @@ class WhiteAestherAppTest {
 
         compose.onNodeWithTag("tab-settings").performClick()
         compose.onNodeWithTag("add-tile-button").assertDoesNotExist()
+    }
+
+    @Test
+    fun tvGamepadButtonsActivateAndNavigateBack() {
+        var requests = 0
+        setApp(television = true, onConnect = { requests++ })
+
+        compose.onNodeWithTag("connect-orb")
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.ButtonA) }
+        compose.runOnIdle { assertEquals(1, requests) }
+
+        compose.onNodeWithTag("tab-routes")
+            .performSemanticsAction(SemanticsActions.RequestFocus) { it.invoke() }
+            .performKeyInput { pressKey(Key.ButtonA) }
+        compose.onNodeWithTag("routes-endpoint")
+            .performScrollTo()
+            .performSemanticsAction(SemanticsActions.RequestFocus) { it.invoke() }
+            .performKeyInput { pressKey(Key.ButtonA) }
+        compose.onNodeWithText("Where it connects to").assertExists()
+
+        compose.onNodeWithTag("back-button")
+            .performSemanticsAction(SemanticsActions.RequestFocus) { it.invoke() }
+            .performKeyInput { pressKey(Key.ButtonB) }
+        compose.onNodeWithTag("routes-endpoint").assertIsFocused()
+    }
+
+    @Test
+    fun tvRoutingRuleFieldCanMoveDownWithoutTouch() {
+        setApp(television = true)
+
+        compose.onNodeWithTag("tab-routes").performClick()
+        compose.onNodeWithTag("routes-routing-rules").performScrollTo().performClick()
+        compose.onNodeWithTag("route-block-field")
+            .performSemanticsAction(SemanticsActions.RequestFocus) { it.invoke() }
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.DirectionDown) }
+
+        compose.onNodeWithTag("route-block-field").assertIsNotFocused()
+        compose.onNodeWithTag("route-direct-field").assertIsFocused()
     }
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.net.VpnService
@@ -31,6 +32,7 @@ import com.whitedns.whiteaesther.service.EngineStatus
 import com.whitedns.whiteaesther.service.EngineLog
 import com.whitedns.whiteaesther.service.EngineStatusStore
 import com.whitedns.whiteaesther.ui.WhiteAestherApp
+import com.whitedns.whiteaesther.ui.TvUiPolicy
 import com.whitedns.whiteaesther.ui.theme.WhiteAestherTheme
 
 class MainActivity : ComponentActivity() {
@@ -192,6 +194,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (TvUiPolicy.isTelevision(resources.configuration.uiMode)) {
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        }
         enableEdgeToEdge()
         batteryExempt = isIgnoringBatteryOptimizations()
         setContent {

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/AetherComponents.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/AetherComponents.kt
@@ -240,6 +240,7 @@ fun CrumbBar(text: String, onBack: (() -> Unit)? = null) {
                     .clip(backShape)
                     .border(1.dp, AetherTheme.colors.line, backShape)
                     .background(AetherTheme.colors.ink2)
+                    .tvControllerActivation(onClick = onBack)
                     .clickable(backInteraction, LocalIndication.current, onClick = onBack)
                     .controllerFocus(backInteraction, backShape)
                     .testTag("back-button"),
@@ -309,6 +310,7 @@ fun RowCard(
             .then(
                 if (onClick != null) {
                     Modifier
+                        .tvControllerActivation(onClick = onClick)
                         .clickable(interaction, LocalIndication.current, onClick = onClick)
                         .controllerFocus(interaction, shape)
                 } else {
@@ -396,6 +398,7 @@ fun ToggleSettingRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .tvControllerActivation { onCheckedChange(!checked) }
             .toggleable(
                 value = checked,
                 interactionSource = interaction,
@@ -426,7 +429,15 @@ fun AetherSwitch(
     Switch(
         checked = checked,
         onCheckedChange = onCheckedChange,
-        modifier = modifier.controllerFocus(interaction, RoundedCornerShape(16.dp)),
+        modifier = modifier
+            .then(
+                if (onCheckedChange != null) {
+                    Modifier.tvControllerActivation { onCheckedChange(!checked) }
+                } else {
+                    Modifier
+                },
+            )
+            .controllerFocus(interaction, RoundedCornerShape(16.dp)),
         interactionSource = interaction,
         colors = SwitchDefaults.colors(
             checkedTrackColor = AetherTheme.colors.brand,
@@ -479,6 +490,7 @@ fun <T> SegGroup(
                             Modifier
                         },
                     )
+                    .tvControllerActivation { onSelect(option) }
                     .clickable(interaction, LocalIndication.current) { onSelect(option) }
                     .controllerFocus(interaction, shape)
                     .testTag("seg-${label(option).lowercase().replace(' ', '-')}"),
@@ -519,6 +531,7 @@ fun ChoiceCard(
                 if (selected) colors.brand.copy(alpha = 0.55f) else colors.line,
                 shape,
             )
+            .tvControllerActivation(onClick = onClick)
             .clickable(interaction, LocalIndication.current, onClick = onClick)
             .controllerFocus(interaction, shape)
             .testTag("choice-${name.lowercase().replace(' ', '-')}")
@@ -579,6 +592,7 @@ fun OptionRow(
                 if (selected) colors.brand.copy(alpha = 0.44f) else Color.Transparent,
                 shape,
             )
+            .tvControllerActivation(onClick = onClick)
             .clickable(interaction, LocalIndication.current, onClick = onClick)
             .controllerFocus(interaction, shape)
             .testTag("option-${title.lowercase().replace(' ', '-')}")
@@ -650,6 +664,7 @@ fun AdvancedSection(
         Row(
             Modifier
                 .fillMaxWidth()
+                .tvControllerActivation(onClick = onToggle)
                 .clickable(interaction, LocalIndication.current, onClick = onToggle)
                 .controllerFocus(interaction, shape)
                 .testTag("advanced-toggle")
@@ -705,6 +720,7 @@ fun AttentionCard(
                             Modifier
                                 .clip(CircleShape)
                                 .border(1.dp, tone.copy(alpha = 0.42f), CircleShape)
+                                .tvControllerActivation(onClick = action)
                                 .clickable(interaction, LocalIndication.current, onClick = action)
                                 .controllerFocus(interaction, CircleShape)
                                 .padding(horizontal = 13.dp, vertical = 7.dp),
@@ -734,6 +750,7 @@ fun PrimaryButton(
             .height(50.dp)
             .clip(shape)
             .background(if (enabled) colors.brand else colors.brand.copy(alpha = 0.4f))
+            .tvControllerActivation(enabled = enabled, onClick = onClick)
             .clickable(interaction, LocalIndication.current, enabled = enabled, onClick = onClick)
             .controllerFocus(interaction, shape, enabled)
             .padding(horizontal = 16.dp),
@@ -762,6 +779,7 @@ fun OutlineButton(
             .clip(shape)
             .background(colors.ink2)
             .border(1.dp, colors.line, shape)
+            .tvControllerActivation(enabled = enabled, onClick = onClick)
             .clickable(interaction, LocalIndication.current, enabled = enabled, onClick = onClick)
             .controllerFocus(interaction, shape, enabled)
             .padding(horizontal = 16.dp),

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/ChainScreen.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/ChainScreen.kt
@@ -181,6 +181,8 @@ private fun SourcesCard(settings: AppSettings, onSettingsChange: (AppSettings) -
     var draft by rememberSaveable { mutableStateOf("") }
     var pasting by rememberSaveable { mutableStateOf(false) }
     var manual by rememberSaveable(chain.manual) { mutableStateOf(chain.manual) }
+    val sourceInteraction = remember { MutableInteractionSource() }
+    val manualInteraction = remember { MutableInteractionSource() }
 
     AetherCard {
         CardHead("Where your nodes come from", "A subscription link, or nodes pasted by hand.")
@@ -189,6 +191,15 @@ private fun SourcesCard(settings: AppSettings, onSettingsChange: (AppSettings) -
             Divider()
             SettingRow(title = source.name, subtitle = source.url) {
                 val removeInteraction = remember(source.url) { MutableInteractionSource() }
+                val removeSource = {
+                    onSettingsChange(
+                        settings.copy(
+                            chain = chain.copy(
+                                sources = chain.sources.filterIndexed { at, _ -> at != index },
+                            ),
+                        ),
+                    )
+                }
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -211,15 +222,12 @@ private fun SourcesCard(settings: AppSettings, onSettingsChange: (AppSettings) -
                         Modifier
                             .clip(CircleShape)
                             .border(1.dp, colors.line, CircleShape)
-                            .clickable(removeInteraction, LocalIndication.current) {
-                                onSettingsChange(
-                                    settings.copy(
-                                        chain = chain.copy(
-                                            sources = chain.sources.filterIndexed { at, _ -> at != index },
-                                        ),
-                                    ),
-                                )
-                            }
+                            .tvControllerActivation(onClick = removeSource)
+                            .clickable(
+                                removeInteraction,
+                                LocalIndication.current,
+                                onClick = removeSource,
+                            )
                             .controllerFocus(removeInteraction, CircleShape)
                             .padding(horizontal = 11.dp, vertical = 6.dp),
                     ) {
@@ -238,7 +246,9 @@ private fun SourcesCard(settings: AppSettings, onSettingsChange: (AppSettings) -
                 onValueChange = { draft = it.take(512) },
                 modifier = Modifier
                     .fillMaxWidth()
+                    .tvTextFieldSupport(sourceInteraction)
                     .testTag("chain-source-field"),
+                interactionSource = sourceInteraction,
                 placeholder = {
                     Text("https://…", style = AetherType.Data, color = colors.text3)
                 },
@@ -292,7 +302,9 @@ private fun SourcesCard(settings: AppSettings, onSettingsChange: (AppSettings) -
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = 120.dp)
+                        .tvTextFieldSupport(manualInteraction)
                         .testTag("chain-manual-field"),
+                    interactionSource = manualInteraction,
                     placeholder = {
                         Text("vless://…", style = AetherType.Data, color = colors.text3)
                     },
@@ -433,6 +445,7 @@ private fun NodeRow(
             .fillMaxWidth()
             // Listed but not selectable. Choosing it would start a chain that
             // cannot authenticate, and the failure would look like the node.
+            .tvControllerActivation(enabled = supported, onClick = onClick)
             .clickable(
                 interactionSource = interaction,
                 indication = LocalIndication.current,

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/ConnectOrb.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/ConnectOrb.kt
@@ -124,6 +124,7 @@ fun ConnectOrb(
         modifier = modifier
             .size(diameter)
             .scale(press)
+            .tvControllerActivation(enabled = enabled, onClick = onClick)
             .clickable(interaction, indication = null, enabled = enabled, onClick = onClick)
             .controllerFocus(interaction, CircleShape, enabled)
             .testTag("connect-orb"),

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
@@ -750,6 +750,7 @@ fun EndpointScreen(
     val custom = settings.endpointMode != EndpointMode.AUTOMATIC
     var endpointText by rememberSaveable { mutableStateOf(settings.customEndpoint) }
     var focused by remember { mutableStateOf(false) }
+    val endpointInteraction = remember { MutableInteractionSource() }
     LaunchedEffect(settings.customEndpoint) {
         if (!focused && settings.customEndpoint != endpointText) endpointText = settings.customEndpoint
     }
@@ -816,8 +817,10 @@ fun EndpointScreen(
                         },
                         modifier = Modifier
                             .fillMaxWidth()
+                            .tvTextFieldSupport(endpointInteraction)
                             .onFocusChanged { focused = it.isFocused }
                             .testTag("custom-endpoint-field"),
+                        interactionSource = endpointInteraction,
                         placeholder = { Text("162.159.197.3:443", style = AetherType.Data, color = colors.text3) },
                         textStyle = AetherType.Data.copy(color = colors.text),
                         supportingText = {
@@ -905,20 +908,22 @@ fun EndpointScreen(
                 val selected = custom && normalized == result.peer
                 val interaction = remember(result.peer) { MutableInteractionSource() }
                 val shape = RoundedCornerShape(14.dp)
+                val selectResult = {
+                    endpointText = result.peer
+                    onSettingsChange(
+                        settings.copy(
+                            endpointMode = EndpointMode.CUSTOM_FIRST,
+                            customEndpoint = result.peer,
+                            customEndpointProtocol = settings.transport,
+                        ),
+                    )
+                }
                 Row(
                     Modifier
                         .fillMaxWidth()
                         .background(if (selected) colors.brand.copy(alpha = 0.08f) else Color.Transparent)
-                        .clickable(interaction, LocalIndication.current) {
-                            endpointText = result.peer
-                            onSettingsChange(
-                                settings.copy(
-                                    endpointMode = EndpointMode.CUSTOM_FIRST,
-                                    customEndpoint = result.peer,
-                                    customEndpointProtocol = settings.transport,
-                                ),
-                            )
-                        }
+                        .tvControllerActivation(onClick = selectResult)
+                        .clickable(interaction, LocalIndication.current, onClick = selectResult)
                         .controllerFocus(interaction, shape)
                         .padding(horizontal = 15.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -1060,6 +1065,7 @@ fun TrafficScreen(
 
                 Divider()
                 Column(Modifier.padding(horizontal = 15.dp, vertical = 13.dp)) {
+                    val portInteraction = remember { MutableInteractionSource() }
                     Text("Local proxy port", style = AetherType.RowTitle, color = colors.text)
                     Text(
                         "Where proxy-only mode listens on this device.",
@@ -1079,7 +1085,9 @@ fun TrafficScreen(
                         },
                         modifier = Modifier
                             .fillMaxWidth()
+                            .tvTextFieldSupport(portInteraction)
                             .testTag("proxy-port-field"),
+                        interactionSource = portInteraction,
                         textStyle = AetherType.Data.copy(color = colors.text),
                         supportingText = { Text("Between 1024 and 65535", style = AetherType.Small) },
                         isError = portText.toIntOrNull() !in 1_024..65_535,
@@ -1337,6 +1345,7 @@ private fun LanCredentialField(
     onValueChange: (String) -> Unit,
 ) {
     val colors = AetherTheme.colors
+    val interaction = remember { MutableInteractionSource() }
     OutlinedTextField(
         value = value,
         // Whitespace is dropped as it is typed rather than trimmed on save: a
@@ -1345,7 +1354,9 @@ private fun LanCredentialField(
         onValueChange = { entered -> onValueChange(entered.filterNot(Char::isWhitespace)) },
         modifier = Modifier
             .fillMaxWidth()
+            .tvTextFieldSupport(interaction)
             .testTag(tag),
+        interactionSource = interaction,
         textStyle = AetherType.Data.copy(color = colors.text),
         label = { Text(label, style = AetherType.Small) },
         singleLine = true,
@@ -1414,12 +1425,15 @@ private fun PlainField(
     onValueChange: (String) -> Unit,
 ) {
     val colors = AetherTheme.colors
+    val interaction = remember { MutableInteractionSource() }
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         modifier = Modifier
             .fillMaxWidth()
+            .tvTextFieldSupport(interaction)
             .testTag(tag),
+        interactionSource = interaction,
         textStyle = AetherType.Data.copy(color = colors.text),
         singleLine = true,
         shape = RoundedCornerShape(14.dp),
@@ -1535,13 +1549,16 @@ private fun RuleField(
     onValueChange: (String) -> Unit,
 ) {
     val colors = AetherTheme.colors
+    val interaction = remember { MutableInteractionSource() }
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(min = 108.dp)
+            .tvTextFieldSupport(interaction)
             .testTag(tag),
+        interactionSource = interaction,
         textStyle = AetherType.Data.copy(color = colors.text),
         placeholder = {
             Text(placeholder, style = AetherType.Data, color = colors.text3)
@@ -1713,6 +1730,9 @@ private fun CommunityFooter() {
     val uriHandler = LocalUriHandler.current
     val interaction = remember { MutableInteractionSource() }
     var unavailable by rememberSaveable { mutableStateOf(false) }
+    val openCommunity = {
+        unavailable = runCatching { uriHandler.openUri("https://t.me/whitedns") }.isFailure
+    }
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -1722,9 +1742,8 @@ private fun CommunityFooter() {
                 .clip(CircleShape)
                 .background(colors.cyan.copy(alpha = 0.10f))
                 .border(1.dp, colors.cyan.copy(alpha = 0.34f), CircleShape)
-                .clickable(interaction, LocalIndication.current) {
-                    unavailable = runCatching { uriHandler.openUri("https://t.me/whitedns") }.isFailure
-                }
+                .tvControllerActivation(onClick = openCommunity)
+                .clickable(interaction, LocalIndication.current, onClick = openCommunity)
                 .controllerFocus(interaction, CircleShape)
                 .testTag("telegram-link")
                 .padding(start = 16.dp, end = 20.dp, top = 11.dp, bottom = 11.dp),
@@ -2050,6 +2069,7 @@ private fun CheckRow(
             .then(
                 if (onCheckedChange != null) {
                     Modifier
+                        .tvControllerActivation { onCheckedChange(!checked) }
                         .toggleable(
                             value = checked,
                             interactionSource = interaction,

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/SplitTunnelScreen.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/SplitTunnelScreen.kt
@@ -87,6 +87,7 @@ fun SplitTunnelScreen(
     }
 
     var query by rememberSaveable { mutableStateOf("") }
+    val searchInteraction = remember { MutableInteractionSource() }
     val visible = remember(apps, query) {
         val all = apps.orEmpty()
         if (query.isBlank()) all else all.filter { it.label.contains(query, ignoreCase = true) }
@@ -167,7 +168,11 @@ fun SplitTunnelScreen(
             OutlinedTextField(
                 value = query,
                 onValueChange = { query = it },
-                modifier = Modifier.fillMaxWidth().testTag("split-search"),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .tvTextFieldSupport(searchInteraction)
+                    .testTag("split-search"),
+                interactionSource = searchInteraction,
                 placeholder = { Text("Search apps", style = AetherType.Body, color = colors.text3) },
                 textStyle = AetherType.Body.copy(color = colors.text),
                 singleLine = true,
@@ -246,6 +251,7 @@ private fun AppRow(app: InstalledApp, checked: Boolean, onToggle: (Boolean) -> U
     Row(
         Modifier
             .fillMaxWidth()
+            .tvControllerActivation { onToggle(!checked) }
             .toggleable(
                 value = checked,
                 interactionSource = interaction,

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/TvSupport.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/TvSupport.kt
@@ -1,0 +1,72 @@
+package com.whitedns.whiteaesther.ui
+
+import android.view.KeyEvent as AndroidKeyEvent
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.dp
+
+/** True only inside the television branch of the shared UI. */
+internal val LocalTvMode = staticCompositionLocalOf { false }
+
+/**
+ * Compose clickables already handle D-pad centre and Enter. Gamepads commonly
+ * report their primary action as BUTTON_A, so handle that key explicitly and
+ * consume it before the clickable can dispatch a duplicate action.
+ */
+internal fun Modifier.tvControllerActivation(
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+): Modifier = composed {
+    if (!LocalTvMode.current || !enabled) return@composed this
+    onPreviewKeyEvent { event ->
+        val activate = event.type == KeyEventType.KeyUp &&
+            event.nativeKeyEvent.keyCode == AndroidKeyEvent.KEYCODE_BUTTON_A
+        if (activate) onClick()
+        activate
+    }
+}
+
+/** Treat the conventional gamepad B button as Back on television. */
+internal fun Modifier.tvControllerBack(onBack: () -> Boolean): Modifier = composed {
+    if (!LocalTvMode.current) return@composed this
+    onPreviewKeyEvent { event ->
+        val back = event.type == KeyEventType.KeyUp &&
+            event.nativeKeyEvent.keyCode == AndroidKeyEvent.KEYCODE_BUTTON_B
+        back && onBack()
+    }
+}
+
+/**
+ * Text fields keep left/right for cursor movement. Up/down leave the field so
+ * a remote cannot become trapped, including inside multiline routing rules.
+ */
+internal fun Modifier.tvTextFieldNavigation(): Modifier = composed {
+    if (!LocalTvMode.current) return@composed this
+    val focusManager = LocalFocusManager.current
+    onPreviewKeyEvent { event ->
+        if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+        when (event.nativeKeyEvent.keyCode) {
+            AndroidKeyEvent.KEYCODE_DPAD_UP -> focusManager.moveFocus(FocusDirection.Up)
+            AndroidKeyEvent.KEYCODE_DPAD_DOWN -> focusManager.moveFocus(FocusDirection.Down)
+            else -> false
+        }
+    }
+}
+
+/** Give Material text fields the same persistent focus outline as other controls. */
+@Composable
+internal fun Modifier.tvTextFieldSupport(
+    interactionSource: MutableInteractionSource,
+): Modifier = controllerFocus(
+    interactionSource = interactionSource,
+    shape = RoundedCornerShape(14.dp),
+).tvTextFieldNavigation()

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/TvUiPolicy.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/TvUiPolicy.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.unit.dp
 internal object TvUiPolicy {
     val safeHorizontalInset = 48.dp
     val safeVerticalInset = 27.dp
-    val maxContentWidth = 720.dp
+    val maxShellWidth = 1_120.dp
 
     fun isTelevision(uiMode: Int): Boolean =
         uiMode and Configuration.UI_MODE_TYPE_MASK == Configuration.UI_MODE_TYPE_TELEVISION

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/WhiteAestherApp.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/WhiteAestherApp.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -29,6 +30,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,8 +43,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
@@ -118,8 +122,8 @@ fun WhiteAestherApp(
     television: Boolean? = null,
 ) {
     var destination by rememberSaveable { mutableStateOf(Destination.HOME) }
-    val colors = AetherTheme.colors
     val isTelevision = television ?: TvUiPolicy.isTelevision(LocalConfiguration.current.uiMode)
+    val inputModeManager = LocalInputModeManager.current
     val connectFocus = remember { FocusRequester() }
     val endpointFocus = remember { FocusRequester() }
     val chainFocus = remember { FocusRequester() }
@@ -144,12 +148,23 @@ fun WhiteAestherApp(
         destination = detail
     }
 
-    fun goBack() {
-        parentOf(destination)?.let { destination = it }
+    fun goBack(): Boolean {
+        parentOf(destination)?.let {
+            destination = it
+            return true
+        }
+        if (isTelevision && destination != Destination.HOME) {
+            destination = Destination.HOME
+            return true
+        }
+        return false
     }
 
     LaunchedEffect(isTelevision) {
-        if (isTelevision && destination == Destination.HOME) connectFocus.requestFocus()
+        if (isTelevision) {
+            inputModeManager.requestInputMode(InputMode.Keyboard)
+            if (destination == Destination.HOME) connectFocus.requestFocus()
+        }
     }
 
     LaunchedEffect(destination) {
@@ -160,36 +175,25 @@ fun WhiteAestherApp(
         }
     }
 
-    BackHandler(enabled = parentOf(destination) != null, onBack = ::goBack)
+    BackHandler(enabled = parentOf(destination) != null) { goBack() }
 
-    Box(
-        Modifier
-            .fillMaxSize()
-            .background(colors.ink1)
-            .then(
-                if (isTelevision) {
-                    Modifier.padding(
-                        horizontal = TvUiPolicy.safeHorizontalInset,
-                        vertical = TvUiPolicy.safeVerticalInset,
-                    )
-                } else {
-                    Modifier.statusBarsPadding()
-                },
-            ),
-    ) {
-        Column(
-            Modifier
-                .align(Alignment.TopCenter)
-                .then(
-                    if (isTelevision) {
-                        Modifier.widthIn(max = TvUiPolicy.maxContentWidth).fillMaxSize()
-                    } else {
-                        Modifier.fillMaxSize()
-                    },
-                ),
+    CompositionLocalProvider(LocalTvMode provides isTelevision) {
+        AetherAppShell(
+            selected = destination.tab,
+            isTelevision = isTelevision,
+            onControllerBack = ::goBack,
+            onSelect = { tab ->
+                returnDestination = null
+                returnFocus = null
+                destination = when (tab) {
+                    Tab.HOME -> Destination.HOME
+                    Tab.ROUTES -> Destination.ROUTES
+                    Tab.TRAFFIC -> Destination.TRAFFIC
+                    Tab.SETTINGS -> Destination.SETTINGS
+                }
+            },
         ) {
-            Box(Modifier.weight(1f)) {
-                when (destination) {
+            when (destination) {
                 Destination.HOME -> HomeScreen(
                     settings = settings,
                     status = engineStatus,
@@ -315,24 +319,107 @@ fun WhiteAestherApp(
                     settings = settings,
                     onBack = ::goBack,
                 )
-                }
             }
-
-            TabBar(
-                selected = destination.tab,
-                isTelevision = isTelevision,
-                onSelect = { tab ->
-                    returnDestination = null
-                    returnFocus = null
-                    destination = when (tab) {
-                        Tab.HOME -> Destination.HOME
-                        Tab.ROUTES -> Destination.ROUTES
-                        Tab.TRAFFIC -> Destination.TRAFFIC
-                        Tab.SETTINGS -> Destination.SETTINGS
-                    }
-                },
-            )
         }
+    }
+}
+
+@Composable
+private fun AetherAppShell(
+    selected: Tab,
+    isTelevision: Boolean,
+    onSelect: (Tab) -> Unit,
+    onControllerBack: () -> Boolean,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    val colors = AetherTheme.colors
+    if (isTelevision) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(colors.ink1)
+                .padding(
+                    horizontal = TvUiPolicy.safeHorizontalInset,
+                    vertical = TvUiPolicy.safeVerticalInset,
+                ),
+            contentAlignment = Alignment.TopCenter,
+        ) {
+            Row(
+                Modifier
+                    .fillMaxSize()
+                    .widthIn(max = TvUiPolicy.maxShellWidth)
+                    .tvControllerBack(onControllerBack),
+            ) {
+                TvNavigationRail(selected = selected, onSelect = onSelect)
+                Box(Modifier.weight(1f).fillMaxSize(), content = content)
+            }
+        }
+    } else {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .background(colors.ink1)
+                .statusBarsPadding(),
+        ) {
+            Box(Modifier.weight(1f), content = content)
+            TabBar(selected = selected, onSelect = onSelect)
+        }
+    }
+}
+
+@Composable
+private fun TvNavigationRail(selected: Tab, onSelect: (Tab) -> Unit) {
+    val colors = AetherTheme.colors
+    Column(
+        modifier = Modifier
+            .widthIn(min = 122.dp, max = 148.dp)
+            .fillMaxSize()
+            .background(colors.ink1)
+            .border(1.dp, colors.line, RoundedCornerShape(18.dp))
+            .padding(horizontal = 12.dp, vertical = 20.dp)
+            .focusGroup(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(AetherIcons.Globe, null, Modifier.size(34.dp), colors.brand)
+        Spacer(Modifier.height(18.dp))
+        Tab.entries.forEach { tab ->
+            val active = tab == selected
+            val interaction = remember { MutableInteractionSource() }
+            val shape = RoundedCornerShape(14.dp)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(shape)
+                    .background(if (active) colors.brand.copy(alpha = 0.12f) else Color.Transparent)
+                    .border(
+                        1.dp,
+                        if (active) colors.brand.copy(alpha = 0.38f) else Color.Transparent,
+                        shape,
+                    )
+                    .tvControllerActivation { onSelect(tab) }
+                    .clickable(interaction, LocalIndication.current) { onSelect(tab) }
+                    .controllerFocus(interaction, shape)
+                    .testTag("tab-${tab.label.lowercase()}")
+                    .padding(horizontal = 8.dp, vertical = 12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Icon(
+                    tab.icon,
+                    null,
+                    Modifier.size(24.dp),
+                    if (active) colors.brand else colors.text3,
+                )
+                Text(
+                    tab.label,
+                    style = AetherType.Small,
+                    color = if (active) colors.text else colors.text3,
+                )
+            }
+        }
+        Spacer(Modifier.weight(1f))
+        SectionLabel("TV")
     }
 }
 
@@ -341,13 +428,13 @@ fun WhiteAestherApp(
  * so the icon and its label share the cell's exact centre line.
  */
 @Composable
-private fun TabBar(selected: Tab, isTelevision: Boolean, onSelect: (Tab) -> Unit) {
+private fun TabBar(selected: Tab, onSelect: (Tab) -> Unit) {
     val colors = AetherTheme.colors
     Column(
         Modifier
             .fillMaxWidth()
             .background(colors.ink1)
-            .then(if (isTelevision) Modifier else Modifier.navigationBarsPadding()),
+            .navigationBarsPadding(),
     ) {
         Box(
             Modifier


### PR DESCRIPTION
This is a focused follow-up to PR #20. It keeps its Android TV manifest, focus restoration, Leanback app discovery, intent fallbacks, and tests, then adds the TV navigation rail, runtime TV landscape policy, explicit gamepad Button A/B handling, D-pad escape from every text field, and forced TV tests that run on any emulator. Verification: stable debug unit tests, lint, app/test APK assembly, 12 targeted TV/controller instrumentation tests, and 19 Chain/Split Tunnel regression tests all passed. Exact-range Codex Security scan 598fefb7-f7cd-4241-9e45-1b21db24968d completed with full coverage and zero findings. No release or signing changes are included.