### PR TITLE
fix(android-tv): make home details reachable by remote

### DIFF
--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/WhiteAestherAppTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/WhiteAestherAppTest.kt
@@ -21,10 +21,13 @@ import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.test.espresso.Espresso.pressBack
+import com.whitedns.whiteaesther.AddressPair
 import com.whitedns.whiteaesther.EndpointScannerState
 import com.whitedns.whiteaesther.data.AppSettings
 import com.whitedns.whiteaesther.data.EndpointMode
+import com.whitedns.whiteaesther.service.EngineStage
 import com.whitedns.whiteaesther.service.EngineStatus
+import com.whitedns.whiteaesther.service.TrafficSample
 import com.whitedns.whiteaesther.ui.theme.WhiteAestherTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -41,13 +44,16 @@ class WhiteAestherAppTest {
         onSettings: (AppSettings) -> Unit = {},
         onConnect: () -> Unit = {},
         television: Boolean? = null,
+        engineStatus: EngineStatus = EngineStatus(),
+        addresses: AddressPair = AddressPair(),
+        traffic: TrafficSample = TrafficSample(),
     ) {
         compose.setContent {
             WhiteAestherTheme {
                 var current by remember { mutableStateOf(initial) }
                 WhiteAestherApp(
                     settings = current,
-                    engineStatus = EngineStatus(),
+                    engineStatus = engineStatus,
                     endpointScannerState = EndpointScannerState(),
                     nativeVersion = "1.7.0+android.0.2.0",
                     onSettingsChange = { current = it; onSettings(it) },
@@ -56,6 +62,8 @@ class WhiteAestherAppTest {
                     onScanEndpoints = { onScan() },
                     onTestEndpoint = {},
                     onCancelEndpointScan = {},
+                    addresses = addresses,
+                    traffic = traffic,
                     batteryExempt = true,
                     television = television,
                 )
@@ -131,6 +139,35 @@ class WhiteAestherAppTest {
             .performKeyInput { pressKey(Key.DirectionCenter) }
 
         compose.runOnIdle { assertEquals(1, requests) }
+    }
+
+    @Test
+    fun tvCanFocusAndScrollPastConnectedTimeToTheLastHomeCard() {
+        setApp(
+            television = true,
+            engineStatus = EngineStatus(
+                stage = EngineStage.CONNECTED,
+                message = "Whole-device traffic is protected",
+                connectedAtMillis = System.currentTimeMillis() - 65_000,
+            ),
+            addresses = AddressPair(real = "198.51.100.10", tunnel = "203.0.113.20"),
+            traffic = TrafficSample(received = 4_096, sent = 2_048),
+        )
+
+        compose.onNodeWithTag("connect-orb")
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.DirectionDown) }
+        compose.onNodeWithTag("home-connected-for").assertIsFocused()
+
+        compose.onNodeWithTag("home-connected-for")
+            .performKeyInput { pressKey(Key.DirectionDown) }
+        compose.onNodeWithTag("home-address").assertIsFocused()
+            .performKeyInput { pressKey(Key.DirectionDown) }
+        compose.onNodeWithTag("home-session").assertIsFocused()
+            .performKeyInput { pressKey(Key.DirectionDown) }
+        compose.onNodeWithTag("home-connection-details")
+            .assertIsFocused()
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/AetherComponents.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/AetherComponents.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -44,6 +45,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.PathParser
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -257,14 +259,28 @@ fun CrumbBar(text: String, onBack: (() -> Unit)? = null) {
 @Composable
 fun AetherCard(
     modifier: Modifier = Modifier,
+    tvFocusable: Boolean = false,
     content: @Composable ColumnScopeAlias.() -> Unit,
 ) {
+    val shape = RoundedCornerShape(20.dp)
+    val tvInteraction = remember { MutableInteractionSource() }
+    val canReceiveTvFocus = tvFocusable && LocalTvMode.current
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(20.dp))
+            .clip(shape)
             .background(AetherTheme.colors.ink2)
-            .border(1.dp, AetherTheme.colors.line, RoundedCornerShape(20.dp)),
+            .border(1.dp, AetherTheme.colors.line, shape)
+            .then(
+                if (canReceiveTvFocus) {
+                    Modifier
+                        .focusable(interactionSource = tvInteraction)
+                        .controllerFocus(tvInteraction, shape)
+                        .semantics(mergeDescendants = true) {}
+                } else {
+                    Modifier
+                },
+            ),
         content = content,
     )
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
@@ -307,7 +307,10 @@ fun HomeScreen(
         }
 
         if (status.stage == EngineStage.CONNECTED) {
-            AetherCard {
+            AetherCard(
+                modifier = Modifier.testTag("home-connected-for"),
+                tvFocusable = true,
+            ) {
                 Column(Modifier.padding(horizontal = 15.dp, vertical = 13.dp)) {
                     SectionLabel("Connected for")
                     Spacer(Modifier.height(3.dp))
@@ -373,7 +376,10 @@ fun HomeScreen(
         }
 
         if (status.stage == EngineStage.CONNECTED || addresses.real != null) {
-            AetherCard {
+            AetherCard(
+                modifier = Modifier.testTag("home-address"),
+                tvFocusable = true,
+            ) {
                 CardHead("Your address")
                 Spacer(Modifier.height(6.dp))
                 FactRow(
@@ -415,7 +421,10 @@ fun HomeScreen(
         }
 
         if (status.stage == EngineStage.CONNECTED || traffic.received > 0 || traffic.sent > 0) {
-            AetherCard {
+            AetherCard(
+                modifier = Modifier.testTag("home-session"),
+                tvFocusable = true,
+            ) {
                 CardHead("This session")
                 Spacer(Modifier.height(6.dp))
                 if (!traffic.supported) {
@@ -465,7 +474,10 @@ fun HomeScreen(
             Spacer(Modifier.height(12.dp))
         }
 
-        AetherCard {
+        AetherCard(
+            modifier = Modifier.testTag("home-connection-details"),
+            tvFocusable = true,
+        ) {
             if (status.stage == EngineStage.CONNECTED) {
                 FactRow("Transport", settings.transport.label)
                 Divider()


### PR DESCRIPTION
## What changed
- make Home information cards focusable only in TV mode
- let D-pad focus movement drive the existing vertical scroll
- add an Android TV instrumentation test that reaches the final Home card

## Safety
- no VPN service, networking, permissions, settings persistence, or native code changes
- phone behavior remains unchanged because the new focus targets are TV-only

## Verification
- Gradle compile + unit tests + AndroidTest compile
- lintStableDebug
- stable debug APK + AndroidTest APK assembly
- targeted TV navigation instrumentation test
- full WhiteAestherAppTest suite: 13/13 passed on API 35 TV-style emulator