### PR TITLE
Stop the address and the endpoint from outliving the network they were found on

### DIFF
--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/BatteryNoticeTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/BatteryNoticeTest.kt
@@ -46,6 +46,7 @@ class BatteryNoticeTest {
                     onStop = {},
                     onScanEndpoints = {},
                     onTestEndpoint = {},
+                    onResetEndpoint = {},
                     onCancelEndpointScan = {},
                     batteryExempt = batteryExempt,
                 )

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/ChainScreenTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/ChainScreenTest.kt
@@ -59,6 +59,7 @@ class ChainScreenTest {
                     onStop = {},
                     onScanEndpoints = {},
                     onTestEndpoint = {},
+                    onResetEndpoint = {},
                     onCancelEndpointScan = {},
                     onSelectChainNode = { selected = it },
                     batteryExempt = true,

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/IdentityBackupTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/IdentityBackupTest.kt
@@ -38,6 +38,7 @@ class IdentityBackupTest {
                     onStop = {},
                     onScanEndpoints = {},
                     onTestEndpoint = {},
+                    onResetEndpoint = {},
                     onCancelEndpointScan = {},
                     identityMessage = message,
                     onExportIdentity = { exported++ },

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/LanSharingTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/LanSharingTest.kt
@@ -66,6 +66,7 @@ class LanSharingTest {
                     onStop = {},
                     onScanEndpoints = {},
                     onTestEndpoint = {},
+                    onResetEndpoint = {},
                     onCancelEndpointScan = {},
                     batteryExempt = true,
                 )

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/SplitTunnelScreenTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/SplitTunnelScreenTest.kt
@@ -59,6 +59,7 @@ class SplitTunnelScreenTest {
                     onStop = {},
                     onScanEndpoints = {},
                     onTestEndpoint = {},
+                    onResetEndpoint = {},
                     onCancelEndpointScan = {},
                     batteryExempt = true,
                 )

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/WhiteAestherAppTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/WhiteAestherAppTest.kt
@@ -41,6 +41,7 @@ class WhiteAestherAppTest {
     private fun setApp(
         initial: AppSettings = AppSettings(),
         onScan: () -> Unit = {},
+        onReset: () -> Unit = {},
         onSettings: (AppSettings) -> Unit = {},
         onConnect: () -> Unit = {},
         television: Boolean? = null,
@@ -61,6 +62,7 @@ class WhiteAestherAppTest {
                     onStop = {},
                     onScanEndpoints = { onScan() },
                     onTestEndpoint = {},
+                    onResetEndpoint = { onReset() },
                     onCancelEndpointScan = {},
                     addresses = addresses,
                     traffic = traffic,
@@ -103,6 +105,27 @@ class WhiteAestherAppTest {
         compose.onNodeWithText("Endpoint").performScrollTo().performClick()
         compose.onNodeWithTag("scan-endpoints-button").performScrollTo().performClick()
         compose.runOnIdle { assertTrue(scanRequested) }
+    }
+
+    @Test
+    fun forgettingTheEndpointClearsTheFieldAndAsksForAFreshSearch() {
+        var resetRequested = false
+        setApp(
+            initial = AppSettings(
+                endpointMode = EndpointMode.CUSTOM_FIRST,
+                customEndpoint = "162.159.197.3:443",
+            ),
+            onReset = { resetRequested = true },
+        )
+
+        compose.onNodeWithTag("tab-routes").performClick()
+        compose.onNodeWithText("Endpoint").performScrollTo().performClick()
+        compose.onNodeWithTag("custom-endpoint-field").assertTextContains("162.159.197.3:443")
+        compose.onNodeWithTag("reset-endpoint-button").performScrollTo().performClick()
+        compose.runOnIdle { assertTrue(resetRequested) }
+        // The field is cleared with the setting, not left showing an address
+        // the app has just been told to forget.
+        compose.onNodeWithTag("custom-endpoint-field").assertTextContains("")
     }
 
     @Test

--- a/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
@@ -264,6 +264,7 @@ class MainActivity : ComponentActivity() {
                     onStop = { AetherVpnService.stop(this) },
                     onScanEndpoints = viewModel::scanEndpoints,
                     onTestEndpoint = viewModel::testEndpoint,
+                    onResetEndpoint = viewModel::resetEndpoint,
                     onCancelEndpointScan = viewModel::cancelEndpointScan,
                     onRefreshChainNodes = { viewModel.refreshChainNodes(settings) },
                     onSelectChainNode = { node -> viewModel.selectChainNode(settings, node) },

--- a/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
@@ -16,6 +16,7 @@ import com.whitedns.whiteaesther.data.EngineMode
 import com.whitedns.whiteaesther.data.TunnelProtocol
 import com.whitedns.whiteaesther.data.SettingsRepository
 import com.whitedns.whiteaesther.data.UpdateChecker
+import com.whitedns.whiteaesther.service.AetherVpnService
 import com.whitedns.whiteaesther.service.EngineStage
 import com.whitedns.whiteaesther.service.EngineStatusStore
 import com.whitedns.whiteaesther.service.TrafficMeter
@@ -507,6 +508,28 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 selected = reported.selected,
             )
         }
+    }
+
+    /**
+     * Forgets the endpoint entirely and looks for a new one.
+     *
+     * Three separate things remember an endpoint, and clearing one of them is
+     * what makes this look like it did nothing: the pinned address in settings,
+     * the results still listed on screen, and the transport the service saw
+     * work last. A pin survives the network it was found on -- an address that
+     * answered on home wifi is just an address that times out on mobile data --
+     * and with fallback off there is nothing to move on to, so the user reads a
+     * dead pin as the app being broken.
+     *
+     * The scan starts here rather than being left to the next connect so that
+     * the reset has something to show for itself.
+     */
+    fun resetEndpoint(settings: AppSettings) {
+        val cleared = settings.withoutPinnedEndpoint()
+        save(cleared)
+        AetherVpnService.forgetLastGoodTransport(getApplication())
+        mutableEndpointScannerState.value = EndpointScannerState()
+        scanEndpoints(cleared)
     }
 
     fun scanEndpoints(settings: AppSettings) {

--- a/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
@@ -129,6 +129,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val mutableEndpointScannerState = MutableStateFlow(EndpointScannerState())
     val endpointScannerState = mutableEndpointScannerState.asStateFlow()
     private var endpointJob: Job? = null
+    private var realAddressJob: Job? = null
 
     // Seeded with what the build can do, rather than waiting for a refresh
     // that only happens once connected. Whether the library is present is known
@@ -141,8 +142,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
      * The address the internet sees, on each side of the tunnel.
      *
      * Two separate lookups rather than one refreshed: the address without the
-     * tunnel is only ever read while there is no tunnel, so it is captured
-     * before connecting and then left alone. Asking again mid-session would
+     * tunnel is only ever read while there is no tunnel. It is re-read each
+     * time the app is idle, because a phone changes networks and the answer
+     * changes with them, but never while a session is up -- asking then would
      * push the user's real address out past the thing hiding it.
      */
     private val mutableAddresses = MutableStateFlow(AddressPair())
@@ -205,21 +207,29 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
      */
     fun captureRealAddressIfIdle() {
         if (EngineStatusStore.status.value.stage != EngineStage.IDLE) return
-        // Held values are revalidated too, not just stored ones: changing the
-        // setting while the app is open would otherwise leave the address that
-        // the old setting produced on screen until the process restarts.
-        val held = mutableAddresses.value.real
-        if (held != null && !held.contains(':')) return
-        viewModelScope.launch {
-            val stored = AddressReporter.realAddress(getApplication(), ipv4Only())
-            if (stored != null) {
+        // One at a time. onResume and the idle transition both arrive here, and
+        // often within the same moment; two fetches would race to write one
+        // field and the loser's answer would be the one left on screen.
+        if (realAddressJob?.isActive == true) return
+        realAddressJob = viewModelScope.launch {
+            val ipv4Only = ipv4Only()
+            val stored = AddressReporter.realAddress(getApplication(), ipv4Only)
+            // Shown first so the row is filled while the network is asked, then
+            // replaced by whatever the network answers.
+            if (stored != null && mutableAddresses.value.real != stored) {
                 mutableAddresses.value = mutableAddresses.value.copy(real = stored)
-                return@launch
             }
-            val fetched = AddressReporter.captureRealAddress(getApplication(), ipv4Only())
-            if (fetched != null) {
-                mutableAddresses.value = mutableAddresses.value.copy(real = fetched)
-            }
+            // Asked again every time, not only when nothing is stored. The
+            // stored answer was true of the network that produced it: move from
+            // wifi to mobile data, or let the ISP hand out a new address, and
+            // it becomes a confident lie that nothing in the app can clear --
+            // the first reading a device ever took would outlive every network
+            // it went on to join. Refreshing is unsafe only while a tunnel is
+            // carrying traffic, and this returns above when one is.
+            val fresh = AddressReporter.captureRealAddress(getApplication(), ipv4Only)
+            // Offline, or a blocked trace, leaves the stored answer standing
+            // rather than blanking a field the user was reading.
+            mutableAddresses.value = mutableAddresses.value.copy(real = fresh ?: stored)
         }
     }
 

--- a/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
@@ -401,6 +401,21 @@ data class AppSettings(
     }
 
     /**
+     * These settings with no endpoint pinned to them.
+     *
+     * Three fields, and clearing two of them is worse than clearing none: an
+     * address left behind with the mode back on automatic is invisible on the
+     * screen but reappears the moment the mode changes, and a protocol left
+     * behind without an address is what [endpointProtocolMismatch] reads to
+     * accuse a pin that no longer exists. They move together or not at all.
+     */
+    fun withoutPinnedEndpoint(): AppSettings = copy(
+        endpointMode = EndpointMode.AUTOMATIC,
+        customEndpoint = "",
+        customEndpointProtocol = null,
+    )
+
+    /**
      * Set when the pinned address belongs to a protocol other than the one now
      * selected, which is a mismatch the user can only fix by knowing about it.
      */

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
@@ -1170,6 +1170,7 @@ class AetherVpnService : VpnService() {
         private const val LAST_CHAIN_CONFIG = "last_chain_config"
         private const val LAST_SPLIT_CONFIG = "last_split_config"
         private const val LAST_GOOD_TRANSPORT = "last_good_transport"
+        private const val PREFS_NAME = "aether_service"
         // How long the chain waits for the tunnel it dials its nodes through.
         // Generous, because that tunnel is itself still searching for a route.
         private const val TUNNEL_WAIT_MS = 120_000L
@@ -1182,6 +1183,22 @@ class AetherVpnService : VpnService() {
         private const val RECONNECT_DELAY_MS = 3_000L
         private const val MAX_RECONNECT_DELAY_MS = 60_000L
         private const val MAX_RECONNECT_ATTEMPTS = 8
+
+        /**
+         * Forgets which transport last carried traffic here.
+         *
+         * That memory is what makes the second connect on a network faster than
+         * the first, and it is also what keeps a phone trying a route that
+         * stopped working -- the ladder starts at the remembered rung, so a
+         * network the device has since left still shapes where it looks. Part
+         * of resetting the endpoint, and pointless on its own: the remembered
+         * rung is only a starting position, and a fresh search finds it again
+         * within one session if it is still the right one.
+         */
+        fun forgetLastGoodTransport(context: Context) {
+            context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+                .edit { remove(LAST_GOOD_TRANSPORT) }
+        }
 
         fun start(
             context: Context,
@@ -1232,6 +1249,6 @@ class AetherVpnService : VpnService() {
     private var blockAfterStop = false
 
     private val preferences by lazy {
-        getSharedPreferences("aether_service", MODE_PRIVATE)
+        getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
     }
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
@@ -794,6 +794,7 @@ fun EndpointScreen(
     onSettingsChange: (AppSettings) -> Unit,
     onScanEndpoints: (AppSettings) -> Unit,
     onTestEndpoint: (AppSettings) -> Unit,
+    onResetEndpoint: (AppSettings) -> Unit,
     onCancelEndpointScan: () -> Unit,
     onBack: () -> Unit,
 ) {
@@ -823,11 +824,7 @@ fun EndpointScreen(
                 actions = listOf(
                     stringResource(R.string.use_automatic) to {
                         onSettingsChange(
-                            settings.copy(
-                                endpointMode = EndpointMode.AUTOMATIC,
-                                customEndpoint = "",
-                                customEndpointProtocol = null,
-                            ),
+                            settings.withoutPinnedEndpoint(),
                         )
                     },
                 ),
@@ -939,6 +936,23 @@ fun EndpointScreen(
                 },
             )
         }
+
+        // Separate from "Find endpoints" above, which searches while leaving a
+        // pinned address in place. This drops the pin first, so a phone that
+        // keeps returning to an address that no longer answers has a way out
+        // that does not involve clearing the field by hand and knowing to.
+        Spacer(Modifier.height(9.dp))
+        OutlineButton(
+            text = stringResource(R.string.forget_and_search_again),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("reset-endpoint-button"),
+            enabled = scannerState.operation == null && !engineBusy,
+            onClick = {
+                endpointText = ""
+                onResetEndpoint(settings)
+            },
+        )
 
         Spacer(Modifier.height(12.dp))
         AetherCard {

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/WhiteAestherApp.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/WhiteAestherApp.kt
@@ -102,6 +102,7 @@ fun WhiteAestherApp(
     onStop: () -> Unit,
     onScanEndpoints: (AppSettings) -> Unit,
     onTestEndpoint: (AppSettings) -> Unit,
+    onResetEndpoint: (AppSettings) -> Unit,
     onCancelEndpointScan: () -> Unit,
     onRefreshChainNodes: () -> Unit = {},
     onSelectChainNode: (String) -> Unit = {},
@@ -261,6 +262,7 @@ fun WhiteAestherApp(
                     onSettingsChange = onSettingsChange,
                     onScanEndpoints = onScanEndpoints,
                     onTestEndpoint = onTestEndpoint,
+                    onResetEndpoint = onResetEndpoint,
                     onCancelEndpointScan = onCancelEndpointScan,
                     onBack = ::goBack,
                 )

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -100,6 +100,7 @@
     <string name="if_this_address_stops_working_search_for">اگر این آدرس از کار افتاد، به‌جای شکست خوردن دنبال آدرس دیگری بگرد.</string>
     <string name="test_this_one">همین را آزمایش کن</string>
     <string name="find_endpoints">یافتن نقاط پایانی</string>
+    <string name="forget_and_search_again">فراموش کردن این نقطهٔ پایانی و جست‌وجوی دوباره</string>
     <string name="endpoints_that_worked">نقاطی که کار کردند</string>
     <string name="not_searched_yet">هنوز جست‌وجو نشده</string>
     <string name="result_rttmillis_ms">%1$s میلی‌ثانیه</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="if_this_address_stops_working_search_for">If this address stops working, search for another instead of failing.</string>
     <string name="test_this_one">Test this one</string>
     <string name="find_endpoints">Find endpoints</string>
+    <string name="forget_and_search_again">Forget this endpoint and search again</string>
     <string name="endpoints_that_worked">Endpoints that worked</string>
     <string name="not_searched_yet">Not searched yet</string>
     <string name="result_rttmillis_ms">%1$s ms</string>

--- a/app/src/test/java/com/whitedns/whiteaesther/data/EndpointProtocolTest.kt
+++ b/app/src/test/java/com/whitedns/whiteaesther/data/EndpointProtocolTest.kt
@@ -13,6 +13,27 @@ class EndpointProtocolTest {
     )
 
     @Test
+    fun forgettingThePinClearsTheAddressTheModeAndTheProtocolTogether() {
+        val cleared = pinned.withoutPinnedEndpoint()
+        assertEquals(EndpointMode.AUTOMATIC, cleared.endpointMode)
+        assertEquals("", cleared.customEndpoint)
+        assertNull(cleared.customEndpointProtocol)
+        // The three move together or the reset is not one: an address kept
+        // behind an automatic mode comes back the moment the mode changes.
+        assertNull(cleared.endpointValidationError())
+        assertNull(cleared.endpointProtocolMismatch())
+    }
+
+    @Test
+    fun forgettingThePinLeavesEverythingElseAlone() {
+        // A reset of the endpoint is not a reset of the settings. The transport
+        // the user chose is the one the fresh search should probe with.
+        val cleared = pinned.copy(transport = TunnelProtocol.H2).withoutPinnedEndpoint()
+        assertEquals(TunnelProtocol.H2, cleared.transport)
+        assertEquals(pinned.copy(transport = TunnelProtocol.H2).dualStack, cleared.dualStack)
+    }
+
+    @Test
     fun anAddressPinnedForTheCurrentProtocolIsNotAMismatch() {
         assertNull(pinned.endpointProtocolMismatch())
         assertNull(pinned.copy(transport = TunnelProtocol.H2).endpointProtocolMismatch())


### PR DESCRIPTION
Two reports from the same root: something read once and then treated as permanent.

**The address without the tunnel never changed again.** `captureRealAddressIfIdle`
asked the network only when nothing was held and nothing was stored, so the first
reading a device ever took was replayed for the life of the install. Move from wifi
to mobile data and the row kept showing the old address -- specific, wrong, and
unclearable by anything short of reinstalling. It is now re-read on every idle pass,
with the stored answer filling the row while the network is asked and standing when
the ask fails. Refreshing while a session is up is still forbidden.

**A pinned endpoint had no way out.** An address found on one network times out on
the next, and with fallback off there is nothing behind it. `Forget this endpoint and
search again` clears the pin, the listed results, and the remembered transport -- all
three, because clearing a subset is what makes a reset look like it did nothing -- and
starts a fresh scan.

`AppSettings.withoutPinnedEndpoint()` exists so the three endpoint fields move
together; the attention card that already offered this now shares it.

Unit tests, lint, and the instrumentation sources compile locally. The native library
was not built here -- no NDK on this machine -- so CI is the first full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)