### PR TITLE
Let Psiphon carry the tunnel when Aether cannot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,14 @@ jobs:
           cargo test --manifest-path native/android-bridge/Cargo.toml --locked
           cargo clippy --manifest-path native/android-bridge/Cargo.toml --locked --all-targets -- -D warnings
 
+      # Psiphon's bootstrap list, which is data rather than code and is not
+      # committed. Gradle packages whatever is staged, so without this the
+      # preview APK installs with the Psiphon carrier present and unable to
+      # start -- the shape of failure that only shows up on a device.
+      - name: Fetch the Psiphon server list
+        shell: pwsh
+        run: ./native/psiphon/setup.ps1
+
       - name: Test, lint and package Android
         run: >-
           ./gradlew
@@ -65,6 +73,13 @@ jobs:
             apk="${apk_dir}/app-preview-${abi}-debug.apk"
             test -f "$apk"
             jar tf "$apk" | grep -F "lib/${abi}/libwhiteaesther_core.so"
+            # The Psiphon carrier, both halves of it. The tunnel core is a
+            # native library that has to match the ABI, and the server list is
+            # an asset a fetch step can silently skip -- either one missing is
+            # a carrier that cannot start on a phone that has already installed
+            # the build.
+            jar tf "$apk" | grep -F "lib/${abi}/libgojni.so"
+            jar tf "$apk" | grep -qF "assets/psiphon_server_entries.txt"
             test "$(jar tf "$apk" | grep -c '^lib/.*/libwhiteaesther_core\.so$')" -eq 1
             ! jar tf "$apk" | grep -E 'lib(quiche|boringtun.*)\.so'
             "${ANDROID_HOME}/build-tools/${ANDROID_BUILD_TOOLS}/aapt2" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,13 @@ jobs:
           ./native/chain/setup.ps1
           ./native/chain/build.ps1
 
+      # Data, not code, and not committed for the same reasons the chain's
+      # source is not. A release built without it ships a Psiphon carrier that
+      # reports its list missing the first time somebody taps connect.
+      - name: Fetch the Psiphon server list
+        shell: pwsh
+        run: ./native/psiphon/setup.ps1
+
       - name: Build signed APKs and bundle
         shell: bash
         run: |
@@ -161,6 +168,8 @@ jobs:
             # chain simply reporting itself unavailable. That is the one failure
             # nobody would notice before users did.
             jar tf "$apk" | grep -F "lib/${abi}/libwhiteaestherchain.so"
+            jar tf "$apk" | grep -F "lib/${abi}/libgojni.so"
+            jar tf "$apk" | grep -qF "assets/psiphon_server_entries.txt"
             test "$(jar tf "$apk" | grep -c '^lib/.*/libwhiteaestherchain\.so$')" -eq 1
             cp "$apk" "release-assets/${base}-${abi}.apk"
           done

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ native/chain/build/
 # Bundled history of the retired WhiteAesther-Android repository. Large, local,
 # and the only surviving copy -- keep a duplicate off this drive.
 archive/
+
+# Psiphon's bootstrap server list. Fetched by native/psiphon/setup.ps1 at a
+# pinned revision and checked against a SHA-256 -- large, regenerable, and not
+# ours, which is the same reason native/chain/third_party is not committed.
+app/src/main/assets/psiphon_server_entries.txt

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ error. It is the first thing to read.
 | What you see | What it means |
 | --- | --- |
 | `... · retry 3 of 8 in 12s` | A path failed and it is trying another. Normal on a hostile network. |
+| `Psiphon is looking for a way out` | The Psiphon carrier is establishing. It tries many protocols at once and a minute is normal. |
 | `Stopped after 8 attempts` | Nothing worked here. Try a different profile or network. |
 | `custom endpoint ... failed MASQUE validation` | The address you pinned is not reachable. Switch **Endpoint** back to Automatic. |
 | `Connected to a different endpoint` | Your pinned address failed and fallback substituted a working one. |
@@ -93,6 +94,10 @@ handshake against them, and only accepts a route once real traffic returns
 through it. The app then either raises an Android `VpnService` tunnel that
 captures IPv4, IPv6 and DNS, or exposes a loopback SOCKS5 proxy.
 
+- **Carrier** — Aether by default. Under **Routes**, Psiphon can carry the
+  tunnel instead: it finds its own way out and the app routes the whole device
+  into it. Slower, and someone else's network, so it is there for the networks
+  Aether cannot get out of rather than as an equal choice
 - **Transports** — MASQUE over HTTP/3 (QUIC) and HTTP/2 (TLS over TCP, for
   networks that block UDP)
 - **Obfuscation** — padding profiles that make tunnel traffic harder to
@@ -125,12 +130,31 @@ Rust bridge itself.
 `./gradlew :app:compileStableDebugKotlin` skips the native build and is the fast
 loop when only touching Kotlin.
 
+Two things Gradle does not build for you. The exit chain's Go library, which the
+Psiphon carrier also needs to reach the interface:
+
+```powershell
+pwsh -File native/chain/setup.ps1
+pwsh -File native/chain/build.ps1
+```
+
+and Psiphon's bootstrap server list, which is data rather than code and is not
+committed:
+
+```powershell
+pwsh -File native/psiphon/setup.ps1
+```
+
+A build missing either still installs and runs; the feature that needs it says
+so rather than failing at connect time on somebody's phone.
+
 ## Repository layout
 
 | Path | |
 | --- | --- |
 | `app/` | The Android application |
 | `native/aether/` | Vendored Aether engine |
+| `native/psiphon/` | The Psiphon carrier: what to fetch, and why it is a separate process |
 | `native/android-bridge/` | Rust JNI bridge between the two |
 | `design/` | Clickable design prototype and the notes from building it |
 | `docs/` | Release process and device test plan |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -48,13 +48,47 @@ Shipped as `libwhiteaestherchain.so`.
 
 ### Getting the source
 
-Neither GPL-3.0 component is committed to this repository — both are fetched at
-build time, at the exact revisions above, by `native/chain/setup.ps1`. Those
+No GPL-3.0 component is committed to this repository. The chain's two are
+fetched at build time, at the exact revisions above, by `native/chain/setup.ps1`;
+psiphon-tunnel-core is resolved as a pinned maven dependency from Psiphon's own
+distribution, and its source for that version is the `v2.0.41` tag of the
+repository named above. Those
 revisions are pinned in that script, so the source corresponding to any binary
 we ship can be obtained by running it, or by fetching the revisions directly
 from the upstreams named above. `native/chain/README.md` describes the build.
 
 The GPL-3.0 text is in [licenses/GPL-3.0.txt](licenses/GPL-3.0.txt).
+
+## psiphon-tunnel-core — GPL-3.0
+
+The Psiphon carrier is
+[Psiphon-Labs/psiphon-tunnel-core](https://github.com/Psiphon-Labs/psiphon-tunnel-core),
+taken as `ca.psiphon:psiphontunnel:2.0.41` from Psiphon's own maven
+distribution at
+`https://raw.githubusercontent.com/Psiphon-Labs/psiphon-tunnel-core-Android-library/master`,
+which corresponds to the `v2.0.41` tag of the source repository.
+
+Unmodified. It runs in its own process (`:psiphon`) and this app talks to it
+through the library's published `PsiphonTunnel` API only.
+
+Shipped inside the APK as `libgojni.so`, which is the library that aar contains.
+
+**The server list.** `app/src/main/assets/psiphon_server_entries.txt` is
+Psiphon's public bootstrap list of server entries, fetched at build time by
+`native/psiphon/setup.ps1` at the pinned revision named in that script rather
+than committed here. It is data Psiphon publishes for clients to start from, not
+code, and tunnel-core verifies every entry itself.
+
+**The identifiers.** `PropagationChannelId` and `SponsorId` in
+`core/PsiphonConfig.kt` are the placeholder values documented in tunnel-core's
+own sample configuration, not a channel issued to this app. See
+`native/psiphon/README.md`.
+
+## mihomo, and this combination
+
+Both GPL-3.0 components above are combined with this AGPL-3.0 app under
+AGPL-3.0 section 13, which expressly permits it. Each part keeps its own
+licence; the GPL-3.0 text is in [licenses/GPL-3.0.txt](licenses/GPL-3.0.txt).
 
 ## BoringSSL Rust bindings — MIT
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,6 +156,13 @@ dependencies {
     implementation("androidx.datastore:datastore-preferences:1.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
 
+    // Psiphon, as its own carrier. Pinned: this is a 44MB binary from outside
+    // the usual supply chain, and "whatever is newest" is not a thing to be
+    // relaxed about there. It runs in its own process -- see PsiphonService --
+    // because it is Go, and the exit chain is already the one Go runtime this
+    // process is allowed to have.
+    implementation("ca.psiphon:psiphontunnel:2.0.41")
+
     implementation("androidx.compose.ui:ui:1.11.4")
     implementation("androidx.compose.ui:ui-tooling-preview:1.11.4")
     implementation("androidx.compose.foundation:foundation:1.11.4")

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/service/PsiphonSessionTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/service/PsiphonSessionTest.kt
@@ -1,0 +1,234 @@
+package com.whitedns.whiteaesther.service
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.whitedns.whiteaesther.data.AppSettings
+import com.whitedns.whiteaesther.data.Carrier
+import com.whitedns.whiteaesther.data.ChainSettings
+import com.whitedns.whiteaesther.data.EngineMode
+import org.junit.After
+import org.junit.Before
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import android.util.Log
+import org.junit.Test
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URL
+
+/**
+ * Brings the Psiphon carrier up on a device and holds it.
+ *
+ * Live, and therefore opt-in. It reaches Psiphon's real network, takes as long
+ * as that network takes, and cannot run on a machine with no way out -- so it
+ * is skipped unless asked for:
+ *
+ *     -Pandroid.testInstrumentationRunnerArguments.psiphon=1
+ *
+ * with VPN consent already granted, because nothing here can tap a dialog:
+ *
+ *     adb shell appops set com.whitedns.whiteaesther ACTIVATE_VPN allow
+ *
+ * `psiphonHold=<seconds>` keeps the tunnel up afterwards. That is not idle
+ * time: the containment check cannot be made from in here, because this process
+ * is excluded from the interface on purpose, so proving that traffic actually
+ * leaves through Psiphon means asking from another uid -- `adb shell curl`
+ * while this holds the tunnel open.
+ */
+class PsiphonSessionTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val requested: Boolean
+        get() = InstrumentationRegistry.getArguments().getString("psiphon") == "1"
+
+    private val holdSeconds: Long
+        get() = InstrumentationRegistry.getArguments().getString("psiphonHold")?.toLongOrNull() ?: 0L
+
+    /**
+     * A clean status before each test, not merely a stopped service.
+     *
+     * [EngineStatusStore] is an object in the app's process and these tests run
+     * in that process, so a failure recorded by one is still standing when the
+     * next begins -- and [awaitStage] returns the moment it sees ERROR. Without
+     * this, the second test to run reads the first one's refusal, returns
+     * immediately, and reports a failure that belongs to a session that has
+     * already ended.
+     */
+    @Before
+    fun clearStatus() {
+        AetherVpnService.stop(context)
+        // Waited for, not slept through. The stop is asynchronous and it writes
+        // a status of its own on the way out; a fixed sleep that guesses short
+        // lets that write land after the clear and put the previous test's
+        // stage straight back -- which the next awaitStage then returns
+        // immediately, reporting a failure that belongs to a session already
+        // over.
+        val deadline = System.currentTimeMillis() + 20_000
+        while (System.currentTimeMillis() < deadline &&
+            EngineStatusStore.status.value.stage != EngineStage.IDLE
+        ) {
+            Thread.sleep(500)
+        }
+        // Psiphon is a separate process and its own teardown is not instant
+        // either. Starting a second tunnel while the first is still unwinding
+        // is a state tunnel-core refuses rather than queues.
+        Thread.sleep(3_000)
+        EngineStatusStore.update(EngineStatus())
+        EngineLog.clear()
+    }
+
+    @After
+    fun tearDown() {
+        AetherVpnService.stop(context)
+    }
+
+    @Test
+    fun psiphonCarriesTheInterfaceAndHolds() {
+        assumeTrue("no psiphon argument, skipping the live carrier test", requested)
+
+        val settings = AppSettings(mode = EngineMode.TUN, carrier = Carrier.PSIPHON)
+        AetherVpnService.start(
+            context,
+            settings.toNativeJson(context),
+            settings.chainForService().encode(),
+            carrier = Carrier.PSIPHON,
+        )
+
+        // Generous, and deliberately longer than tunnel-core's own establish
+        // timeout. Psiphon works by trying a ladder of protocols against a
+        // network that may be dropping most of them, and a test that gives up
+        // first would report the app broken for doing exactly what it should.
+        val stage = awaitStage(EngineStage.CONNECTED, timeoutMs = 180_000)
+        assertEquals(
+            "psiphon did not carry the interface: ${EngineStatusStore.status.value.message}",
+            EngineStage.CONNECTED,
+            stage,
+        )
+
+        // The carrier is another process, and the log line naming its port is
+        // the only evidence from in here that the two ever agreed on one. A
+        // session that reports CONNECTED without it is mihomo holding an
+        // interface pointed at a listener that was never there.
+        assertTrue(
+            "nothing from the carrier reached the log",
+            EngineLog.entries.value.any { it.tag == "carrier" && it.message.contains("is up on") },
+        )
+        // Waited for rather than read once. mihomo's log is drained on a timer
+        // and the first drain lands seconds after the interface is already
+        // carrying traffic -- asserting immediately would be testing the
+        // drain interval rather than whether the log arrives at all.
+        assertTrue(
+            "no log from mihomo reached the app",
+            awaitLog("chain", timeoutMs = 20_000),
+        )
+
+        if (holdSeconds > 0) {
+            // Mirrored to logcat while holding, because the point of holding is
+            // to make requests from another uid and watch what mihomo does with
+            // them -- and its log lives in this process, where a shell cannot
+            // reach it.
+            var seen = 0
+            val deadline = System.currentTimeMillis() + holdSeconds * 1000
+            while (System.currentTimeMillis() < deadline) {
+                val entries = EngineLog.entries.value
+                entries.drop(seen).forEach { Log.i("carrier-diag", "${it.tag}: ${it.message}") }
+                seen = entries.size
+                Thread.sleep(2_000)
+            }
+            assertEquals(
+                "the carrier did not stay up",
+                EngineStage.CONNECTED,
+                EngineStatusStore.status.value.stage,
+            )
+        }
+    }
+
+    @Test
+    fun theCarriersOwnProxyActuallyCarriesARequest() {
+        assumeTrue("no psiphon argument, skipping the live carrier test", requested)
+
+        val settings = AppSettings(mode = EngineMode.TUN, carrier = Carrier.PSIPHON)
+        AetherVpnService.start(
+            context,
+            settings.toNativeJson(context),
+            settings.chainForService().encode(),
+            carrier = Carrier.PSIPHON,
+        )
+        assertEquals(
+            "psiphon did not carry the interface: ${EngineStatusStore.status.value.message}",
+            EngineStage.CONNECTED,
+            awaitStage(EngineStage.CONNECTED, timeoutMs = 180_000),
+        )
+
+        // Asked from this process on purpose, which is the only reason this
+        // test can exist: our uid is excluded from the interface, so a request
+        // from here reaches the listener directly instead of being routed back
+        // into the tunnel that is carrying it. It separates the two halves --
+        // whether Psiphon can carry a request at all, and whether mihomo hands
+        // it one -- which otherwise fail identically from outside.
+        val port = carrierPort()
+        assertTrue("the carrier never reported a port", port > 0)
+
+        val proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", port))
+        // https, because this app blocks cleartext by policy -- and a test
+        // that had to relax that policy would be testing a build nobody
+        // ships.
+        val body = URL("https://checkip.amazonaws.com/").openConnection(proxy).run {
+            connectTimeout = 30_000
+            readTimeout = 30_000
+            getInputStream().bufferedReader().use { it.readText() }
+        }.trim()
+
+        assertTrue("psiphon returned nothing for a plain request", body.isNotBlank())
+        EngineLog.record(LogLevel.INFO, "carrier", "psiphon exits at $body")
+    }
+
+    @Test
+    fun proxyOnlyCoverageIsRefusedRatherThanQuietlyCarryingNothing() {
+        assumeTrue("no psiphon argument, skipping the live carrier test", requested)
+
+        // Psiphon's listener is not the one applications are pointed at, and
+        // there is no second one to offer. Starting anyway would leave the user
+        // looking at a connected screen with a proxy port that answers nothing.
+        val settings = AppSettings(mode = EngineMode.PROXY, carrier = Carrier.PSIPHON)
+        AetherVpnService.start(
+            context,
+            settings.toNativeJson(context),
+            ChainSettings().encode(),
+            carrier = Carrier.PSIPHON,
+        )
+
+        val stage = awaitStage(EngineStage.ERROR, timeoutMs = 30_000)
+        assertEquals(EngineStage.ERROR, stage)
+        assertTrue(
+            "the refusal did not say why: ${EngineStatusStore.status.value.message}",
+            EngineStatusStore.status.value.message.contains("proxy", ignoreCase = true),
+        )
+    }
+
+    /** The port the carrier reported, read back out of the log line naming it. */
+    private fun carrierPort(): Int =
+        EngineLog.entries.value
+            .lastOrNull { it.tag == "carrier" && it.message.contains("is up on 127.0.0.1:") }
+            ?.message?.substringAfterLast(':')?.trim()?.toIntOrNull()
+            ?: 0
+
+    private fun awaitLog(tag: String, timeoutMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (EngineLog.entries.value.any { it.tag == tag }) return true
+            Thread.sleep(500)
+        }
+        return false
+    }
+
+    private fun awaitStage(target: EngineStage, timeoutMs: Long): EngineStage {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val current = EngineStatusStore.status.value.stage
+            if (current == target || current == EngineStage.ERROR) return current
+            Thread.sleep(500)
+        }
+        return EngineStatusStore.status.value.stage
+    }
+}

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/ui/WhiteAestherAppTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/ui/WhiteAestherAppTest.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.Espresso.pressBack
 import com.whitedns.whiteaesther.AddressPair
 import com.whitedns.whiteaesther.EndpointScannerState
 import com.whitedns.whiteaesther.data.AppSettings
+import com.whitedns.whiteaesther.data.Carrier
 import com.whitedns.whiteaesther.data.EndpointMode
 import com.whitedns.whiteaesther.service.EngineStage
 import com.whitedns.whiteaesther.service.EngineStatus
@@ -126,6 +127,43 @@ class WhiteAestherAppTest {
         // The field is cleared with the setting, not left showing an address
         // the app has just been told to forget.
         compose.onNodeWithTag("custom-endpoint-field").assertTextContains("")
+    }
+
+    @Test
+    fun theCarrierCanBeChosenAndIsCarriedIntoTheSettings() {
+        var saved: AppSettings? = null
+        setApp(onSettings = { saved = it })
+
+        compose.onNodeWithTag("tab-routes").performClick()
+        compose.onNodeWithTag("option-psiphon").performScrollTo().performClick()
+        compose.runOnIdle { assertEquals(Carrier.PSIPHON, saved?.carrier) }
+    }
+
+    @Test
+    fun choosingACarrierSaysTheEngineControlsNoLongerApply() {
+        // The endpoint, the protocol and the discovery depth all describe a
+        // search for a Cloudflare gateway. A carrier that never looks for one
+        // leaves that whole half of the screen inert, and a screen full of
+        // controls that quietly do nothing is worse than a sentence saying so.
+        setApp(initial = AppSettings(carrier = Carrier.PSIPHON))
+
+        compose.onNodeWithTag("tab-routes").performClick()
+        compose.onNodeWithText(
+            "Endpoint, protocol and discovery depth below apply to Aether only. " +
+                "This carrier finds its own way out.",
+        ).performScrollTo().assertExists()
+    }
+
+    @Test
+    fun aetherIsTheCarrierUntilSomethingSaysOtherwise() {
+        // The default matters more than it looks. Psiphon is somebody else's
+        // network, and an install that silently began using it would be a
+        // decision made for the user rather than by them.
+        assertEquals(Carrier.AETHER, AppSettings().carrier)
+
+        setApp()
+        compose.onNodeWithTag("tab-routes").performClick()
+        compose.onNodeWithTag("option-aether").performScrollTo().assertExists()
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <!--
       Lets the app list what the user can actually launch, for per-app routing.
       QUERY_ALL_PACKAGES would return every service and provider too, is a
@@ -49,9 +50,18 @@
     -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!--
+      tools:replace, because psiphontunnel declares backup rules of its own and
+      this app does not do backups at all. The merger cannot decide between
+      "false" and a rules file, and getting this wrong is not a build problem:
+      it is Psiphon's data store, which holds what the device has connected to,
+      being eligible for Google's cloud backup on a phone whose owner was told
+      in PRIVACY.md that nothing here is backed up. Ours wins deliberately.
+    -->
     <application
         android:name=".WhiteAestherApplication"
         android:allowBackup="false"
+        tools:replace="android:fullBackupContent"
         android:banner="@drawable/tv_banner"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="false"
@@ -112,5 +122,22 @@
                 android:name="android.service.quicksettings.ACTIVE_TILE"
                 android:value="false" />
         </service>
+
+        <!--
+          Psiphon, in its own process, and that is the entire point of the
+          declaration. Its tunnel core is Go and so is the exit chain; one
+          process may host one Go runtime, because two of them export the same
+          runtime symbols into a single linker namespace and a call that binds
+          to the wrong copy takes the process down.
+
+          Not exported and not startable from outside: it takes no action that
+          another app has any business asking for, and the only thing it
+          produces is a proxy on loopback.
+        -->
+        <service
+            android:name=".service.PsiphonService"
+            android:process=":psiphon"
+            android:exported="false" />
+
     </application>
 </manifest>

--- a/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
@@ -426,6 +426,7 @@ class MainActivity : ComponentActivity() {
             settings.splitTunnel.encode(),
             settings.killSwitch,
             settings.strictKillSwitch,
+            settings.carrier,
         )
     }
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/core/ChainConfig.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/ChainConfig.kt
@@ -47,10 +47,19 @@ object ChainConfig {
     private const val HEALTH_CHECK_URL = "http://www.gstatic.com/generate_204"
 
     /**
-     * @param socksPort the port Aether's SOCKS5 listener is on, or null to dial
-     *   nodes directly rather than through the tunnel.
+     * @param socksPort the port the carrying tunnel's SOCKS5 listener is on, or
+     *   null to dial nodes directly rather than through a tunnel.
+     * @param proxyName what that tunnel is called in the config it appears in.
+     *   Named rather than fixed because the engine is no longer the only thing
+     *   that can be in front of the chain: a carrier ends in the same shape of
+     *   listener, and a config calling Psiphon "aether" would mislead every log
+     *   line and screen that reads a proxy name back.
      */
-    fun render(settings: ChainSettings, socksPort: Int?): String = buildString {
+    fun render(
+        settings: ChainSettings,
+        socksPort: Int?,
+        proxyName: String = TUNNEL_PROXY,
+    ): String = buildString {
         // No external-controller. The desktop needs one because mihomo is a
         // separate process there; in-process we drive it through the action
         // protocol, so binding a control API would add an attack surface that
@@ -62,15 +71,15 @@ object ChainConfig {
         // for every connection costs a /proc walk per socket on a phone.
         append("find-process-mode: off\n")
 
-        appendDns(socksPort)
+        appendDns(socksPort, proxyName)
 
         val through = if (socksPort != null) {
             append("proxies:\n")
             append(
-                "  - {name: $TUNNEL_PROXY, type: socks5, server: 127.0.0.1, " +
+                "  - {name: $proxyName, type: socks5, server: 127.0.0.1, " +
                     "port: $socksPort, udp: true}\n",
             )
-            "\n    dialer-proxy: $TUNNEL_PROXY"
+            "\n    dialer-proxy: $proxyName"
         } else {
             ""
         }
@@ -85,6 +94,82 @@ object ChainConfig {
         append("  - name: $EXIT_GROUP\n    type: select\n    use: [${names.joinToString(", ")}]\n")
 
         appendRules(settings)
+    }
+
+    /** The SOCKS5 proxy standing in for a carrier that is not the engine. */
+    const val CARRIER_PROXY = "carrier"
+
+    /**
+     * Everything through one upstream SOCKS5, with no exit chain in front.
+     *
+     * This is what a carrier that is not the engine needs from mihomo, and it is
+     * less than [render] does: there are no nodes to choose from and no group to
+     * choose with, only a proxy and a default route into it. mihomo is here as
+     * the thing that terminates the interface -- Psiphon hands us a listener on
+     * loopback, and a listener cannot carry a tun.
+     *
+     * The user's block and direct rules still apply. They are the same rules the
+     * engine path honours, and a different carrier is not a reason to stop.
+     *
+     * \nparam socksPort the carrier's SOCKS5 listener, with its tunnel already
+     *   established. A port that is merely listening is not enough: traffic
+     *   routed into a proxy whose tunnel has not come up is dropped rather than
+     *   refused, which the phone experiences as everything hanging.
+     * \nparam udp whether the carrier forwards UDP. Psiphon does. Tor does not,
+     *   and a proxy declared `udp: true` that cannot carry it swallows every
+     *   datagram -- DNS and QUIC failing silently while TCP works, which is the
+     *   hardest shape of broken to recognise.
+     */
+    fun renderCarrier(settings: ChainSettings, socksPort: Int, udp: Boolean = true): String =
+        buildString {
+            append("mode: rule\n")
+            append("log-level: info\n")
+            append("ipv6: true\n")
+            append("find-process-mode: off\n")
+
+            appendDns(socksPort, CARRIER_PROXY)
+
+            append("proxies:\n")
+            append(
+                "  - {name: $CARRIER_PROXY, type: socks5, server: 127.0.0.1, " +
+                    "port: $socksPort, udp: $udp}\n",
+            )
+
+            // A group of one, rather than routing to the proxy by name. mihomo
+            // reports health and traffic per group, so the screens and the logs
+            // can describe a carrier exactly as they describe an exit node
+            // instead of having a second shape to understand.
+            append("proxy-groups:\n")
+            append("  - name: $EXIT_GROUP\n    type: select\n    proxies: [$CARRIER_PROXY]\n")
+
+            appendCarrierRules(settings, udp)
+        }
+
+    /**
+     * The rules for a carrier: the ordinary ones, plus what it cannot do.
+     *
+     * A carrier with no UDP gets an explicit refusal for it. Without one the
+     * datagrams match `MATCH` and are handed to a proxy that drops them, and
+     * dropping is worse than refusing: a refused datagram makes a resolver fall
+     * back to TCP and a browser fall back off QUIC, while a dropped one makes
+     * both wait out a timeout on every request.
+     */
+    private fun StringBuilder.appendCarrierRules(settings: ChainSettings, udp: Boolean) {
+        append("rules:\n")
+        settings.blockRules().forEach { pattern ->
+            mihomoRules(pattern, "REJECT").forEach { append("  - $it\n") }
+        }
+        settings.directRules().forEach { pattern ->
+            mihomoRules(pattern, "DIRECT").forEach { append("  - $it\n") }
+        }
+        if (!udp) {
+            // After the user's rules and before MATCH: a destination they chose
+            // to block stays blocked, and one they chose to send direct still
+            // goes direct over UDP, because direct does not go through this
+            // carrier at all.
+            append("  - NETWORK,udp,REJECT\n")
+        }
+        append("  - MATCH,$EXIT_GROUP\n")
     }
 
     /**
@@ -176,8 +261,8 @@ object ChainConfig {
      * question. The `#$TUNNEL_PROXY` fragment is mihomo's syntax for dialling a
      * resolver through a named proxy, which is what keeps that from happening.
      */
-    private fun StringBuilder.appendDns(socksPort: Int?) {
-        val via = if (socksPort != null) "#$TUNNEL_PROXY" else ""
+    private fun StringBuilder.appendDns(socksPort: Int?, proxyName: String = TUNNEL_PROXY) {
+        val via = if (socksPort != null) "#$proxyName" else ""
         append("dns:\n")
         append("  enable: true\n")
         append("  ipv6: true\n")

--- a/app/src/main/java/com/whitedns/whiteaesther/core/ChainController.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/ChainController.kt
@@ -67,6 +67,74 @@ class ChainController(private val context: Context) {
     }
 
     /**
+     * Routes [tunFd] into a carrier's SOCKS5 listener.
+     *
+     * The same mihomo, doing less. [start] gives it a subscription to fetch and
+     * a group to choose from; this gives it one proxy and a default route, and
+     * uses it purely as the thing that turns an interface into connections. It
+     * is the only thing in the build that can: Psiphon produces a listener on
+     * loopback and nothing else, and a listener cannot carry a tun.
+     *
+     * No provider fetch happens here, which is why this returns in milliseconds
+     * where [start] can take a while -- there is nothing to go and get.
+     *
+     * @param socksPort the carrier's listener, tunnel already established.
+     * @param udp whether the carrier forwards datagrams.
+     * @return null on success, or why it failed.
+     */
+    fun startCarrier(
+        settings: ChainSettings,
+        socksPort: Int,
+        udp: Boolean,
+        tunFd: Int,
+    ): String? {
+        if (!isAvailable) return "This build cannot route a carrier: the chain library is missing"
+
+        return runCatching {
+            if (settings.enabled) {
+                // The exit chain, dialled through the carrier instead of through
+                // the engine. Same arrangement the engine path uses -- mihomo
+                // owns the interface and reaches each node through a loopback
+                // SOCKS5 -- so a user who has set up an exit chain keeps it when
+                // they switch carrier, rather than having it silently dropped.
+                //
+                // prepareHome, not a bare write: this path fetches providers,
+                // and that fetch travels through the carrier's listener, which
+                // is why the carrier has to be established before we get here.
+                prepareHome(settings, socksPort, ChainConfig.CARRIER_PROXY)
+            } else {
+                home.mkdirs()
+                File(home, "config.yaml").writeText(
+                    ChainConfig.renderCarrier(settings, socksPort, udp),
+                )
+            }
+
+            initialise()?.let { return it }
+            applyConfig()?.let { return it }
+            if (settings.enabled) selectNode(settings.node)
+            startLogging()
+
+            val failure = NativeChainBridge.startTun(
+                fd = tunFd,
+                stack = ChainConfig.TUN_STACK,
+                address = "${ChainConfig.TUN_IPV4},${ChainConfig.TUN_IPV6}",
+                dns = ChainConfig.TUN_DNS,
+            ).failureText()
+            if (failure == null) {
+                // Deliberately not a fingerprint of [settings]. A carrier's
+                // configuration is the port it was handed, and that changes
+                // every time the carrier restarts -- treating it as current
+                // because the user's chain settings have not moved would leave
+                // a config pointed at a port nothing is listening on.
+                applied = null
+            }
+            failure
+        }.getOrElse { error ->
+            error.message ?: "The carrier route did not start"
+        }
+    }
+
+    /**
      * Whether the running engine was configured from [settings].
      *
      * The node list comes from the live engine, so after editing a subscription
@@ -207,11 +275,15 @@ class ChainController(private val context: Context) {
         else -> LogLevel.INFO
     }
 
-    private fun prepareHome(settings: ChainSettings, socksPort: Int?) {
+    private fun prepareHome(
+        settings: ChainSettings,
+        socksPort: Int?,
+        proxyName: String = ChainConfig.TUNNEL_PROXY,
+    ) {
         home.mkdirs()
         val providers = File(home, "providers")
         providers.mkdirs()
-        File(home, "config.yaml").writeText(ChainConfig.render(settings, socksPort))
+        File(home, "config.yaml").writeText(ChainConfig.render(settings, socksPort, proxyName))
 
         // Cached node lists for subscriptions the user has since removed. They
         // are not merely clutter: mihomo keys its own state by provider name, so

--- a/app/src/main/java/com/whitedns/whiteaesther/core/PsiphonClient.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/PsiphonClient.kt
@@ -1,0 +1,171 @@
+package com.whitedns.whiteaesther.core
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import com.whitedns.whiteaesther.service.PsiphonService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * What the Psiphon process is doing, as seen from this one.
+ *
+ * [port] is set as soon as the listener exists, which is before the tunnel is
+ * established -- the two are separate because routing into a listener with no
+ * tunnel behind it is a way to drop traffic silently.
+ */
+data class PsiphonState(
+    val state: PsiphonService.State = PsiphonService.State.STOPPED,
+    val port: Int = 0,
+    val failure: String? = null,
+)
+
+/**
+ * The near side of [PsiphonService].
+ *
+ * Binding rather than broadcasting, for two reasons that both matter here. A
+ * bound service with [Context.BIND_IMPORTANT] is raised to the importance of the
+ * binder, which for us is a foreground VpnService -- an unbound background
+ * process carrying a tunnel is one the system may reclaim while the screen is
+ * off. And a Messenger delivers to whoever is bound now, so a state change
+ * cannot be missed by a client that was not listening yet: the service answers
+ * a registration with the current state rather than only the next one.
+ */
+class PsiphonClient(private val context: Context) {
+    private val mutableState = MutableStateFlow(PsiphonState())
+    val state = mutableState
+
+    private var outgoing: Messenger? = null
+    private var connection: ServiceConnection? = null
+
+    private val incoming = Messenger(
+        object : Handler(Looper.getMainLooper()) {
+            override fun handleMessage(message: Message) {
+                if (message.what != PsiphonService.MSG_STATE) {
+                    super.handleMessage(message)
+                    return
+                }
+                val state = PsiphonService.State.entries
+                    .getOrElse(message.arg1) { PsiphonService.State.STOPPED }
+                mutableState.value = PsiphonState(
+                    state = state,
+                    port = message.arg2,
+                    failure = message.peekData()?.getString(PsiphonService.EXTRA_FAILURE),
+                )
+            }
+        },
+    )
+
+    /**
+     * Starts Psiphon and waits for a tunnel.
+     *
+     * @return the loopback SOCKS5 port, or a failure describing why there is
+     *   none. A timeout is reported as a failure rather than as a port that
+     *   might work later: the caller is about to route an interface into this,
+     *   and a proxy with no tunnel behind it swallows packets rather than
+     *   refusing them.
+     */
+    suspend fun start(egressRegion: String, timeoutMs: Long): Result<Int> {
+        bind()
+        context.startService(
+            Intent(context, PsiphonService::class.java)
+                .setAction(PsiphonService.ACTION_START)
+                .putExtra(PsiphonService.EXTRA_REGION, egressRegion),
+        )
+
+        val settled = withTimeoutOrNull(timeoutMs) {
+            mutableState.first { snapshot ->
+                when (snapshot.state) {
+                    PsiphonService.State.CONNECTED -> snapshot.port > 0
+                    PsiphonService.State.FAILED -> true
+                    // STOPPED is the state before the service has answered as
+                    // much as it is the state after it gives up, so it is not
+                    // an outcome on its own.
+                    else -> false
+                }
+            }
+        }
+
+        return when {
+            settled == null -> Result.failure(
+                IllegalStateException("Psiphon did not connect in ${timeoutMs / 1000}s"),
+            )
+            settled.state == PsiphonService.State.FAILED -> Result.failure(
+                IllegalStateException(settled.failure ?: "Psiphon failed to start"),
+            )
+            else -> Result.success(settled.port)
+        }
+    }
+
+    fun stop() {
+        runCatching {
+            context.startService(
+                Intent(context, PsiphonService::class.java).setAction(PsiphonService.ACTION_STOP),
+            )
+        }
+        unbind()
+        mutableState.value = PsiphonState()
+    }
+
+    private suspend fun bind() {
+        if (connection != null) return
+        val established = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val newConnection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                val messenger = Messenger(binder)
+                outgoing = messenger
+                runCatching {
+                    messenger.send(
+                        Message.obtain(null, PsiphonService.MSG_REGISTER).apply { replyTo = incoming },
+                    )
+                }
+                established.complete(Unit)
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                // The process died. Reported as a failure rather than left at
+                // whatever it last said, because the caller is waiting on a
+                // state that is never going to arrive now.
+                outgoing = null
+                mutableState.value = PsiphonState(
+                    state = PsiphonService.State.FAILED,
+                    failure = "The Psiphon process stopped unexpectedly",
+                )
+            }
+        }
+        connection = newConnection
+        context.bindService(
+            Intent(context, PsiphonService::class.java),
+            newConnection,
+            Context.BIND_AUTO_CREATE or Context.BIND_IMPORTANT,
+        )
+        // Bounded: bindService can simply never call back if the component is
+        // missing from the manifest, and a suspend that waits forever there is
+        // a connect button that never returns.
+        withTimeoutOrNull(BIND_TIMEOUT_MS) { established.await() }
+    }
+
+    private fun unbind() {
+        outgoing?.let { messenger ->
+            runCatching {
+                messenger.send(
+                    Message.obtain(null, PsiphonService.MSG_UNREGISTER).apply { replyTo = incoming },
+                )
+            }
+        }
+        outgoing = null
+        connection?.let { runCatching { context.unbindService(it) } }
+        connection = null
+    }
+
+    private companion object {
+        const val BIND_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/core/PsiphonConfig.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/PsiphonConfig.kt
@@ -1,0 +1,90 @@
+package com.whitedns.whiteaesther.core
+
+import android.content.Context
+import com.whitedns.whiteaesther.BuildConfig
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * The configuration psiphon-tunnel-core is started with.
+ *
+ * Kept small deliberately. Every field here is one this app has a reason to set;
+ * tunnel-core has dozens more and its defaults are chosen against live censored
+ * networks by people who measure them, which is not something to second-guess
+ * from here.
+ */
+object PsiphonConfig {
+    /**
+     * Psiphon's own documented values for a client that has not been issued its
+     * own.
+     *
+     * `PropagationChannelId` and `SponsorId` identify who distributed a client,
+     * so that Psiphon can attribute usage and target server capacity. Real ones
+     * are issued by Psiphon Inc. to partners; these two are the all-Fs and
+     * all-1s placeholders that appear throughout tunnel-core's own tests and
+     * every open-source client that has not asked for a channel of its own.
+     *
+     * They work, and they are not credentials -- nothing here is authenticated
+     * by them. What they cost is that this app's sessions are indistinguishable
+     * from every other unattributed client, so Psiphon cannot tell our users
+     * apart from anyone else's when they plan capacity. If this carrier turns
+     * out to matter to the people using it, asking Psiphon for a channel is the
+     * honest next step rather than a technical one.
+     */
+    private const val PROPAGATION_CHANNEL_ID = "FFFFFFFFFFFFFFFF"
+    private const val SPONSOR_ID = "1111111111111111"
+
+    /** Where the embedded bootstrap list is packaged. */
+    const val SERVER_ENTRIES_ASSET = "psiphon_server_entries.txt"
+
+    /**
+     * How long tunnel-core tries before giving up and letting us decide.
+     *
+     * Not unlimited, which is its default. An unlimited establish means a
+     * carrier that never reports failure, and the service above it can neither
+     * retry nor tell the user that this network is not working -- the screen
+     * would say "connecting" until the phone was rebooted.
+     */
+    private const val ESTABLISH_TIMEOUT_SECONDS = 120
+
+    /** Everything tunnel-core writes, under one directory we can delete. */
+    fun dataDirectory(context: Context): File =
+        File(context.filesDir, "psiphon").apply { mkdirs() }
+
+    /**
+     * @param egressRegion a two-letter country code to exit from, or empty for
+     *   whichever Psiphon considers best. Not a guarantee: tunnel-core treats an
+     *   unreachable region as a reason to fail rather than to substitute, which
+     *   is why the screen presents it as a preference and defaults to empty.
+     */
+    fun render(context: Context, egressRegion: String = ""): String {
+        val json = JSONObject()
+        json.put("PropagationChannelId", PROPAGATION_CHANNEL_ID)
+        json.put("SponsorId", SPONSOR_ID)
+        // Our own build number, as a string, which is what tunnel-core's sample
+        // says and what it rejects the config for getting wrong. Psiphon uses
+        // this for their statistics and their upgrade prompt; reporting one of
+        // Psiphon's own client versions would put our sessions in someone
+        // else's column, and reporting "1" tells them nothing at all.
+        json.put("ClientVersion", BuildConfig.VERSION_CODE.toString())
+        json.put("DataRootDirectory", dataDirectory(context).absolutePath)
+        json.put("EgressRegion", egressRegion)
+        json.put("EstablishTunnelTimeoutSeconds", ESTABLISH_TIMEOUT_SECONDS)
+
+        // Zero means "pick a free one and tell me", and the port that comes back
+        // is what the chain is configured against. A fixed port would be one
+        // more thing that can already be taken on a phone we do not control,
+        // and the failure would look like Psiphon not starting.
+        json.put("LocalSocksProxyPort", 0)
+        // Nothing asks for an HTTP proxy. A listener nobody uses is a listener
+        // on loopback that some other app on the phone can reach.
+        json.put("DisableLocalHTTPProxy", true)
+
+        // Diagnostic notices are how anything here is debuggable at all: without
+        // them a failed establish is a silent one. They are written to our log,
+        // which never leaves the device unless the user sends a report.
+        json.put("EmitDiagnosticNotices", true)
+        json.put("EmitDiagnosticNetworkParameters", false)
+        return json.toString()
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
@@ -70,6 +70,49 @@ enum class TunnelProtocol(val wireName: String, @StringRes val label: Int) {
         }
 }
 
+/**
+ * What carries the tunnel.
+ *
+ * Deliberately not another [TunnelProtocol]. Every member of that enum answers
+ * questions about Cloudflare endpoints -- which family it dials, what a scan
+ * probes it with, whether a retry may swap it for its sibling -- and Psiphon and
+ * Tor answer none of them, because neither has anything to do with an endpoint.
+ * Folding them in would mean inventing a family for a carrier that has none and
+ * then teaching every `when` to ignore it.
+ *
+ * They meet in one place instead: each carrier ends in a SOCKS5 listener on
+ * loopback, and mihomo routes the interface into whichever one is running.
+ */
+enum class Carrier(val wireName: String, @StringRes val label: Int) {
+    /** The MASQUE engine this app is built around. */
+    AETHER("aether", R.string.carrier_aether),
+
+    /**
+     * Psiphon, in its own process.
+     *
+     * Go, and the exit chain already spends this process's one Go runtime. Two
+     * `-buildmode=c-shared` libraries export the same runtime symbols into one
+     * linker namespace and the second call to bind to the wrong copy takes down
+     * the process, so Psiphon is loaded somewhere else entirely.
+     */
+    PSIPHON("psiphon", R.string.carrier_psiphon),
+    ;
+
+    /** True when the Aether engine is in the path at all. */
+    val usesEngine: Boolean get() = this == AETHER
+
+    /**
+     * True when the carrier needs mihomo to reach the interface.
+     *
+     * Everything that is not the engine arrives as a SOCKS5 listener, and a
+     * listener cannot carry a tun on its own. mihomo is what terminates the
+     * packets and dials them out through it -- so on a build without the chain
+     * library these carriers cannot run at all, and the screen says so rather
+     * than starting something that would route nothing.
+     */
+    val needsChain: Boolean get() = this != AETHER
+}
+
 /** Protocols sharing one set of endpoints, so an address found on one fits the other. */
 enum class EndpointFamily {
     MASQUE,
@@ -161,6 +204,14 @@ private const val NEWLINE = '\n'
 data class AppSettings(
     val mode: EngineMode = EngineMode.TUN,
     val proxyPort: Int = 1819,
+    /**
+     * Which engine carries the tunnel.
+     *
+     * Aether unless the user says otherwise. The others are here for the
+     * networks Aether cannot get out of, not as an equal choice: they are
+     * slower, and one of them is somebody else's network.
+     */
+    val carrier: Carrier = Carrier.AETHER,
     // Automatic, because the answer depends on the network and the user has no
     // way to know it. A fixed default of H3 meant every install on a network
     // that blocks UDP spent minutes failing before anything else was tried.

--- a/app/src/main/java/com/whitedns/whiteaesther/data/SettingsRepository.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/SettingsRepository.kt
@@ -18,6 +18,7 @@ class SettingsRepository(private val context: Context) {
             mode = enumValueOrDefault(preferences[MODE], EngineMode.TUN),
             proxyPort = preferences[PROXY_PORT]?.coerceIn(1_024, 65_535) ?: 1819,
             transport = enumValueOrDefault(preferences[TRANSPORT], TunnelProtocol.AUTO),
+            carrier = enumValueOrDefault(preferences[CARRIER], Carrier.AETHER),
             scanStrategy = enumValueOrDefault(preferences[SCAN], ScanStrategy.BALANCED),
             dualStack = preferences[DUAL_STACK] ?: true,
             validationEnabled = preferences[VALIDATION] ?: true,
@@ -60,6 +61,7 @@ class SettingsRepository(private val context: Context) {
             preferences[MODE] = settings.mode.name
             preferences[PROXY_PORT] = settings.proxyPort
             preferences[TRANSPORT] = settings.transport.name
+            preferences[CARRIER] = settings.carrier.name
             preferences[SCAN] = settings.scanStrategy.name
             preferences[DUAL_STACK] = settings.dualStack
             preferences[VALIDATION] = settings.validationEnabled
@@ -100,6 +102,7 @@ class SettingsRepository(private val context: Context) {
         val MODE = stringPreferencesKey("mode")
         val PROXY_PORT = intPreferencesKey("proxy_port")
         val TRANSPORT = stringPreferencesKey("transport")
+        val CARRIER = stringPreferencesKey("carrier")
         val SCAN = stringPreferencesKey("scan")
         val DUAL_STACK = booleanPreferencesKey("dual_stack")
         val VALIDATION = booleanPreferencesKey("validation")

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherTileService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherTileService.kt
@@ -80,6 +80,7 @@ class AetherTileService : TileService() {
                 settings.splitTunnel.encode(),
                 settings.killSwitch,
                 settings.strictKillSwitch,
+                settings.carrier,
             )
         }
     }

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
@@ -18,6 +18,8 @@ import com.whitedns.whiteaesther.core.ChainController
 import com.whitedns.whiteaesther.core.NativeAetherBridge
 import com.whitedns.whiteaesther.core.NativeEngineListener
 import com.whitedns.whiteaesther.core.NativeSocketProtector
+import com.whitedns.whiteaesther.core.PsiphonClient
+import com.whitedns.whiteaesther.data.Carrier
 import com.whitedns.whiteaesther.data.ChainSettings
 import com.whitedns.whiteaesther.data.EngineMode
 import com.whitedns.whiteaesther.data.SplitTunnel
@@ -73,7 +75,16 @@ class AetherVpnService : VpnService() {
     private var baseConfigJson: String? = null
     private var chainJson: String? = null
     private var splitJson: String? = null
+    /**
+     * Which engine is carrying this session.
+     *
+     * Held rather than read from the config, because it is not the engine's
+     * business: the JSON handed to the bridge describes MASQUE, and a
+     * carrier that is not the engine never reaches the bridge at all.
+     */
+    private var carrier: Carrier = Carrier.AETHER
     private val chain by lazy { ChainController(this) }
+    private val psiphon by lazy { PsiphonClient(this) }
 
     override fun onCreate() {
         super.onCreate()
@@ -101,6 +112,9 @@ class AetherVpnService : VpnService() {
                 }
                 val chainSettings = intent.getStringExtra(EXTRA_CHAIN)
                 val splitSettings = intent.getStringExtra(EXTRA_SPLIT)
+                carrier = Carrier.entries
+                    .firstOrNull { it.wireName == intent.getStringExtra(EXTRA_CARRIER) }
+                    ?: Carrier.AETHER
                 // Held for the life of the session: giveUp runs long after
                 // this, and is not a place that can read DataStore.
                 blockOnFailure = intent.getBooleanExtra(EXTRA_KILL_SWITCH, false)
@@ -110,6 +124,7 @@ class AetherVpnService : VpnService() {
                         putString(LAST_TUN_CONFIG, configJson)
                         putString(LAST_CHAIN_CONFIG, chainSettings)
                         putString(LAST_SPLIT_CONFIG, splitSettings)
+                        putString(LAST_CARRIER, carrier.wireName)
                     }
                     restartPolicy = START_STICKY
                 } else {
@@ -117,6 +132,7 @@ class AetherVpnService : VpnService() {
                         remove(LAST_TUN_CONFIG)
                         remove(LAST_CHAIN_CONFIG)
                         remove(LAST_SPLIT_CONFIG)
+                        remove(LAST_CARRIER)
                     }
                 }
                 startForegroundNow(sayNow(R.string.status_preparing_connection), sayNow(R.string.status_validating_engine))
@@ -127,6 +143,9 @@ class AetherVpnService : VpnService() {
                 if (configJson == null) {
                     stopSelf(startId)
                 } else {
+                    carrier = Carrier.entries
+                        .firstOrNull { it.wireName == preferences.getString(LAST_CARRIER, null) }
+                        ?: Carrier.AETHER
                     restartPolicy = START_STICKY
                     startForegroundNow(sayNow(R.string.status_restoring), sayNow(R.string.status_reconnecting_tun))
                     replaceSession(
@@ -154,6 +173,7 @@ class AetherVpnService : VpnService() {
         dropBlackhole()
         generation += 1
         runCatching { chain.stop() }
+        runCatching { psiphon.stop() }
         NativeAetherBridge.stop()
         runCatching { NativeAetherBridge.setSocketProtector(null) }
         serviceScope.cancel()
@@ -174,6 +194,7 @@ class AetherVpnService : VpnService() {
                 splitJson = splitSettings
                 NativeAetherBridge.stop()
                 runCatching { chain.stop() }
+                runCatching { psiphon.stop() }
                 sessionJob?.join()
                 val sessionGeneration = generation
                 sessionJob = serviceScope.launch {
@@ -193,6 +214,12 @@ class AetherVpnService : VpnService() {
 
         val chainSettings = ChainSettings.decode(chainJson)
         val splitTunnel = SplitTunnel.decode(splitJson)
+
+        if (carrier != Carrier.AETHER) {
+            runCarrierSession(configJson, mode, chainSettings, splitTunnel, sessionGeneration)
+            return
+        }
+
         val useChain =
             chainSettings.enabled && resolveChainUsage(chainSettings, mode, sessionGeneration)
         if (chainSettings.enabled && !useChain) return
@@ -356,6 +383,158 @@ class AetherVpnService : VpnService() {
             mode = mode,
             sessionGeneration = sessionGeneration,
         )
+    }
+
+    /**
+     * Runs a carrier that is not the engine.
+     *
+     * Shorter than the engine path because there is no endpoint to find, no
+     * identity to provision and no MASQUE handshake to validate: the carrier
+     * either produces a working SOCKS5 listener or it does not, and everything
+     * after that is mihomo turning the interface into connections through it.
+     *
+     * The order is the same one [runChainSession] is careful about, and for the
+     * same reason. The interface is raised first because raising it needs the
+     * user's consent and that is worth failing on early; but it is handed to
+     * mihomo last, after the carrier is up and the rules are written, because
+     * mihomo with no configuration routes everything DIRECT and a DIRECT route
+     * from this process leaves the phone in the clear.
+     */
+    private suspend fun runCarrierSession(
+        configJson: String,
+        mode: EngineMode,
+        chainSettings: ChainSettings,
+        splitTunnel: SplitTunnel,
+        sessionGeneration: Long,
+    ) {
+        val name = carrier.wireName
+        EngineLog.record(LogLevel.INFO, "carrier", "carrying this session on $name")
+        startEngineLogPump(sessionGeneration)
+
+        // Whole-device only, and refused rather than quietly substituted. In
+        // proxy mode the app's own listener is what applications are pointed
+        // at, and this carrier has no listener of ours to offer -- Psiphon's is
+        // on a port it chose, without the validation or the LAN rules that
+        // listener carries. Starting anyway would leave the user pointed at a
+        // port that answers nothing.
+        if (mode != EngineMode.TUN) {
+            reportError(mode, sayNow(R.string.err_carrier_whole_device_only))
+            finishIfCurrent(sessionGeneration)
+            return
+        }
+
+        // The one build-time failure worth naming precisely. Without the chain
+        // library there is nothing that can turn an interface into connections,
+        // so this carrier cannot run at all -- and saying "not available in this
+        // build" beats an interface that comes up and carries nothing.
+        if (!chain.isAvailable) {
+            reportError(mode, sayNow(R.string.err_carrier_needs_chain))
+            finishIfCurrent(sessionGeneration)
+            return
+        }
+
+        EngineStatusStore.update(
+            EngineStatus(EngineStage.PREPARING, mode, message = sayNow(R.string.status_starting_carrier)),
+        )
+        updateNotification(mode, sayNow(R.string.status_starting_carrier))
+
+        if (prepare(this) != null) {
+            reportError(mode, sayNow(R.string.err_permission_required))
+            finishIfCurrent(sessionGeneration)
+            return
+        }
+
+        // forChain, because that is exactly what this is from the interface's
+        // point of view: mihomo owns it, the addresses are its, and this
+        // package is excluded from it. That exclusion is not a nicety here --
+        // the carrier runs in another process and protect() cannot reach its
+        // sockets, so the interface not carrying our own uid is the only thing
+        // keeping the carrier's traffic out of the tunnel it is building.
+        val tun = establishTun("", "", forChain = true, transport = name, splitTunnel = splitTunnel)
+        if (tun == null) {
+            reportError(mode, sayNow(R.string.err_no_interface))
+            finishIfCurrent(sessionGeneration)
+            return
+        }
+        val tunFd = tun.detachFd()
+
+        if (sessionGeneration != generation) {
+            runCatching { psiphon.stop() }
+            return
+        }
+
+        EngineStatusStore.update(
+            EngineStatus(EngineStage.CONNECTING, mode, null, sayNow(R.string.status_carrier_connecting)),
+        )
+        updateNotification(mode, sayNow(R.string.status_carrier_connecting))
+
+        val port = psiphon.start("", PSIPHON_WAIT_MS).getOrElse { error ->
+            val reason = error.message ?: sayNow(R.string.err_carrier_failed)
+            EngineLog.record(LogLevel.ERROR, "carrier", reason)
+            runCatching { psiphon.stop() }
+            if (sessionGeneration != generation) return
+            scheduleReconnect(configJson, sessionGeneration, mode, reason)
+            return
+        }
+
+        if (sessionGeneration != generation) {
+            runCatching { psiphon.stop() }
+            return
+        }
+
+        EngineLog.record(LogLevel.INFO, "carrier", "$name is up on 127.0.0.1:$port")
+        EngineStatusStore.update(
+            EngineStatus(EngineStage.CONNECTING, mode, null, sayNow(R.string.status_starting_chain)),
+        )
+
+        val failure = withContext(Dispatchers.IO) {
+            chain.startCarrier(
+                settings = chainSettings,
+                socksPort = port,
+                // Psiphon forwards UDP over its own tunnel. The flag exists for
+                // the carriers that do not, where declaring it would make DNS
+                // and QUIC fail silently rather than fall back.
+                udp = true,
+                tunFd = tunFd,
+            )
+        }
+        if (failure != null) {
+            EngineLog.record(LogLevel.ERROR, "chain", failure)
+            runCatching { chain.stop() }
+            runCatching { psiphon.stop() }
+            if (sessionGeneration != generation) return
+            scheduleReconnect(configJson, sessionGeneration, mode, failure)
+            return
+        }
+
+        serviceScope.launch {
+            while (sessionGeneration == generation) {
+                delay(EVENT_DRAIN_MS)
+                withContext(Dispatchers.IO) { chain.collectEvents() }
+            }
+        }
+
+        reconnectAttempt = 0
+        reportConnected(mode, null, sayNow(R.string.status_carrier_carries, sayNow(carrier.label)))
+
+        // Watched rather than assumed. The carrier is in another process and can
+        // be killed on its own -- by the system reclaiming memory, or by its own
+        // tunnel giving up -- and mihomo would keep the interface up dialling a
+        // listener that has gone, which the phone experiences as connected and
+        // carrying nothing.
+        psiphon.state.collect { snapshot ->
+            if (sessionGeneration != generation) return@collect
+            if (snapshot.state == PsiphonService.State.FAILED ||
+                snapshot.state == PsiphonService.State.STOPPED
+            ) {
+                val reason = snapshot.failure ?: sayNow(R.string.err_carrier_stopped)
+                EngineLog.record(LogLevel.ERROR, "carrier", reason)
+                runCatching { chain.stop() }
+                runCatching { psiphon.stop() }
+                scheduleReconnect(configJson, sessionGeneration, mode, reason)
+                return@collect
+            }
+        }
     }
 
     /**
@@ -1170,6 +1349,12 @@ class AetherVpnService : VpnService() {
         private const val LAST_CHAIN_CONFIG = "last_chain_config"
         private const val LAST_SPLIT_CONFIG = "last_split_config"
         private const val LAST_GOOD_TRANSPORT = "last_good_transport"
+        private const val EXTRA_CARRIER = "carrier"
+        private const val LAST_CARRIER = "last_carrier"
+        // Psiphon establishes over a network that is actively hostile to it,
+        // and its own timeout is two minutes. Ours has to be the longer of
+        // the two or we would tear down a tunnel that was about to arrive.
+        private const val PSIPHON_WAIT_MS = 150_000L
         private const val PREFS_NAME = "aether_service"
         // How long the chain waits for the tunnel it dials its nodes through.
         // Generous, because that tunnel is itself still searching for a route.
@@ -1207,6 +1392,7 @@ class AetherVpnService : VpnService() {
             splitJson: String? = null,
             killSwitch: Boolean = false,
             strictKillSwitch: Boolean = false,
+            carrier: Carrier = Carrier.AETHER,
         ) {
             ContextCompat.startForegroundService(
                 context,
@@ -1216,7 +1402,12 @@ class AetherVpnService : VpnService() {
                     .putExtra(EXTRA_CHAIN, chainJson)
                     .putExtra(EXTRA_SPLIT, splitJson)
                     .putExtra(EXTRA_KILL_SWITCH, killSwitch)
-                    .putExtra(EXTRA_STRICT_KILL, strictKillSwitch),
+                    .putExtra(EXTRA_STRICT_KILL, strictKillSwitch)
+                    // By name rather than by ordinal. An ordinal is a promise
+                    // about the order of an enum that nothing enforces, and a
+                    // carrier added in the middle of the list would silently
+                    // reinterpret a pending intent written by the old build.
+                    .putExtra(EXTRA_CARRIER, carrier.wireName),
             )
         }
 

--- a/app/src/main/java/com/whitedns/whiteaesther/service/PsiphonService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/PsiphonService.kt
@@ -1,0 +1,217 @@
+package com.whitedns.whiteaesther.service
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import android.os.RemoteException
+import android.util.Log
+import ca.psiphon.PsiphonTunnel
+import com.whitedns.whiteaesther.core.PsiphonConfig
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Psiphon, in a process of its own.
+ *
+ * The process is the whole reason this class exists. psiphon-tunnel-core is Go,
+ * and so is the exit chain; two `-buildmode=c-shared` Go runtimes in one linker
+ * namespace export the same symbols and the first call to bind to the wrong copy
+ * enters a runtime that has never heard of the calling goroutine. `:psiphon` in
+ * the manifest is what keeps them apart, and it costs an IPC hop that carries
+ * four integers.
+ *
+ * What it produces is a SOCKS5 listener on loopback. It never sees the tun and
+ * never asks for one -- [PsiphonTunnel.setVpnMode] is false, so tunnel-core
+ * routes nothing and merely proxies. The interface belongs to
+ * [AetherVpnService], which hands it to mihomo pointed at the port reported
+ * back from here.
+ *
+ * Its own sockets must leave by the physical network or the tunnel would be
+ * carrying the thing that builds it. `protect()` cannot help: that is a call on
+ * a descriptor in the VpnService's process and these are in this one. What does
+ * help is that both processes share a uid, and the interface excludes this
+ * package -- see `applySplitTunnel(excludeSelf = true)`, which is unconditional
+ * on the chain path this carrier always takes.
+ */
+class PsiphonService : Service() {
+    private var tunnel: PsiphonTunnel? = null
+    private val clients = mutableListOf<Messenger>()
+    private val socksPort = AtomicInteger(0)
+    private var state = State.STOPPED
+    private var failure: String? = null
+
+    enum class State { STOPPED, CONNECTING, CONNECTED, FAILED }
+
+    private val handler = object : Handler(Looper.getMainLooper()) {
+        override fun handleMessage(message: Message) {
+            when (message.what) {
+                MSG_REGISTER -> message.replyTo?.let { client ->
+                    clients += client
+                    // Answered immediately rather than only on the next change.
+                    // A client that binds after the tunnel is already up would
+                    // otherwise wait for an event that has been and gone.
+                    send(client, stateMessage())
+                }
+                MSG_UNREGISTER -> message.replyTo?.let(clients::remove)
+                else -> super.handleMessage(message)
+            }
+        }
+    }
+
+    private val messenger = Messenger(handler)
+
+    override fun onBind(intent: Intent?) = messenger.binder
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> start(intent.getStringExtra(EXTRA_REGION).orEmpty())
+            ACTION_STOP -> {
+                stopTunnel()
+                stopSelf()
+                return START_NOT_STICKY
+            }
+        }
+        // Never restarted by the system on its own. This process carries traffic
+        // only while the interface above it exists, and one revived without it
+        // would be a Psiphon tunnel nothing is routed into.
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        stopTunnel()
+        super.onDestroy()
+    }
+
+    private fun start(egressRegion: String) {
+        if (tunnel != null) return
+        state = State.CONNECTING
+        failure = null
+        socksPort.set(0)
+        broadcast()
+
+        val entries = runCatching {
+            assets.open(PsiphonConfig.SERVER_ENTRIES_ASSET).bufferedReader().use { it.readText() }
+        }.getOrElse { error ->
+            // The list is fetched at build time, not committed, so a build that
+            // skipped native/psiphon/setup.ps1 arrives here. Saying so beats a
+            // tunnel that spends two minutes dialling an empty list.
+            fail("The Psiphon server list is missing from this build (${error.message})")
+            return
+        }
+
+        val host = object : PsiphonTunnel.HostService {
+            override fun getContext(): Context = this@PsiphonService
+            override fun getPsiphonConfig(): String =
+                PsiphonConfig.render(this@PsiphonService, egressRegion)
+
+            override fun onListeningSocksProxyPort(port: Int) {
+                socksPort.set(port)
+                // Not connected yet: the listener is up before a tunnel is, and
+                // routing into it now would send packets into a proxy with
+                // nowhere to forward them. The port is carried so the chain can
+                // be rendered while the tunnel finishes establishing.
+                broadcast()
+            }
+
+            override fun onConnected() {
+                state = State.CONNECTED
+                broadcast()
+            }
+
+            override fun onConnecting() {
+                // Reconnects land here too, after a CONNECTED. The interface
+                // above stays up either way -- mihomo holds the tun and the
+                // SOCKS listener does not go away -- so this is reported rather
+                // than acted on.
+                if (state == State.CONNECTED) {
+                    state = State.CONNECTING
+                    broadcast()
+                }
+            }
+
+            override fun onExiting() {
+                if (state != State.FAILED) {
+                    state = State.STOPPED
+                    broadcast()
+                }
+            }
+
+            override fun onDiagnosticMessage(message: String) {
+                // logcat, not EngineLog. EngineLog is an object, so this
+                // process has its own copy of it and nothing written here
+                // would ever reach the Diagnostics screen -- and tunnel-core
+                // emits hundreds of notices while establishing, which would
+                // evict the engine's own entries from a 400-line buffer if
+                // they were forwarded. What the user's report needs is the
+                // state changes and the failure, and those cross on their own.
+                Log.d("psiphon", message)
+            }
+        }
+
+        runCatching {
+            PsiphonTunnel.newPsiphonTunnel(host).also {
+                tunnel = it
+                // Proxy only. VPN mode is tunnel-core building its own
+                // interface, and there is already one of those.
+                it.setVpnMode(false)
+                it.startTunneling(entries)
+            }
+        }.onFailure { error ->
+            tunnel = null
+            fail(error.message ?: "Psiphon did not start")
+        }
+    }
+
+    private fun stopTunnel() {
+        val running = tunnel ?: return
+        tunnel = null
+        runCatching { running.stop() }
+        socksPort.set(0)
+        if (state != State.FAILED) state = State.STOPPED
+        broadcast()
+    }
+
+    private fun fail(reason: String) {
+        state = State.FAILED
+        failure = reason
+        Log.e("psiphon", reason)
+        broadcast()
+    }
+
+    private fun stateMessage(): Message = Message.obtain(null, MSG_STATE).apply {
+        arg1 = state.ordinal
+        arg2 = socksPort.get()
+        failure?.let { data = Bundle().apply { putString(EXTRA_FAILURE, it) } }
+    }
+
+    private fun broadcast() {
+        // Copied before iterating: send() prunes the list when a client's
+        // process has gone, and that is a modification mid-iteration.
+        clients.toList().forEach { send(it, stateMessage()) }
+    }
+
+    private fun send(client: Messenger, message: Message) {
+        try {
+            client.send(message)
+        } catch (_: RemoteException) {
+            // The other side died. Dropping it here is the only cleanup there
+            // is: a Messenger has no death notification of its own.
+            clients.remove(client)
+        }
+    }
+
+    companion object {
+        const val ACTION_START = "com.whitedns.whiteaesther.PSIPHON_START"
+        const val ACTION_STOP = "com.whitedns.whiteaesther.PSIPHON_STOP"
+        const val EXTRA_REGION = "region"
+        const val EXTRA_FAILURE = "failure"
+
+        const val MSG_REGISTER = 1
+        const val MSG_UNREGISTER = 2
+        const val MSG_STATE = 3
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
@@ -62,6 +62,7 @@ import com.whitedns.whiteaesther.IdentityMessage
 import com.whitedns.whiteaesther.R
 import com.whitedns.whiteaesther.data.AppLanguage
 import com.whitedns.whiteaesther.data.AppSettings
+import com.whitedns.whiteaesther.data.Carrier
 import com.whitedns.whiteaesther.data.EndpointAddress
 import com.whitedns.whiteaesther.data.EndpointFamily
 import com.whitedns.whiteaesther.data.EndpointMode
@@ -688,6 +689,39 @@ fun RoutesScreen(
                         if (pair.size == 1) Spacer(Modifier.weight(1f))
                     }
                 }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+        AetherCard {
+            CardHead(
+                stringResource(R.string.carrier),
+                stringResource(R.string.carrier_subtitle),
+            )
+            Column(Modifier.padding(11.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Carrier.entries.forEach { carrier ->
+                    OptionRow(
+                        code = carrier.wireName.take(3).uppercase(),
+                        title = stringResource(carrier.label),
+                        subtitle = when (carrier) {
+                            Carrier.AETHER -> stringResource(R.string.carrier_aether_detail)
+                            Carrier.PSIPHON -> stringResource(R.string.carrier_psiphon_detail)
+                        },
+                        selected = settings.carrier == carrier,
+                        // OptionRow tags itself from the title, so this row is
+                        // reachable in a test as option-aether / option-psiphon.
+                        onClick = { onSettingsChange(settings.copy(carrier = carrier)) },
+                    )
+                }
+            }
+            // Said here rather than left for the user to discover at connect
+            // time. Everything below this card -- the endpoint, the protocol,
+            // the discovery depth -- describes a search for a Cloudflare
+            // gateway, and a carrier that never looks for one makes all of it
+            // inert. A screen full of controls that quietly do nothing is worse
+            // than a sentence saying so.
+            if (!settings.carrier.usesEngine) {
+                Note(stringResource(R.string.carrier_not_engine_note))
             }
         }
 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -451,4 +451,20 @@
     <string name="err_cannot_open_location">آن مکان باز نشد</string>
     <string name="err_cannot_read_file">آن فایل خوانده نشد</string>
     <string name="share_diagnostics">ارسال اطلاعات تشخیصی</string>
+    <string name="carrier_aether">اتر</string>
+    <string name="carrier_psiphon">سایفون</string>
+    <string name="carrier">حامل</string>
+    <string name="carrier_subtitle">کدام موتور تونل را حمل می‌کند</string>
+    <string name="carrier_aether_detail">MASQUE روی کلودفلر. سریع‌ترین مسیر، و چیزی که بقیهٔ اپ حول آن ساخته شده.</string>
+    <string name="carrier_psiphon_detail">شبکهٔ خودِ سایفون. کندتر، و سرورهای شخص دیگری — برای شبکه‌هایی که اتر از آن‌ها بیرون نمی‌رود.</string>
+    <string name="carrier_needs_chain_notice">این نسخه نمی‌تواند سایفون را اجرا کند: کتابخانهٔ مسیریابی موردنیازش موجود نیست.</string>
+    <string name="carrier_whole_device_notice">سایفون فقط کل دستگاه را حمل می‌کند. پوشش را به «کل دستگاه» برگردانید یا اتر را انتخاب کنید.</string>
+    <string name="status_starting_carrier">آماده‌سازی حامل…</string>
+    <string name="status_carrier_connecting">سایفون دنبال راه خروج می‌گردد. ممکن است یک دقیقه طول بکشد.</string>
+    <string name="status_carrier_carries">متصل از طریق %1$s</string>
+    <string name="err_carrier_whole_device_only">سایفون در حالت فقط-پراکسی اجرا نمی‌شود</string>
+    <string name="err_carrier_needs_chain">این نسخه نمی‌تواند سایفون را مسیریابی کند: کتابخانهٔ زنجیره موجود نیست</string>
+    <string name="err_carrier_failed">سایفون نتوانست وصل شود</string>
+    <string name="err_carrier_stopped">سایفون متوقف شد</string>
+    <string name="carrier_not_engine_note">نقطهٔ پایانی، پروتکل و عمق جست‌وجوی پایین فقط برای اتر هستند. این حامل خودش راه خروجش را پیدا می‌کند.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -457,4 +457,20 @@
     <string name="err_cannot_open_location">could not open that location</string>
     <string name="err_cannot_read_file">could not read that file</string>
     <string name="share_diagnostics">Send diagnostics</string>
+    <string name="carrier_aether">Aether</string>
+    <string name="carrier_psiphon">Psiphon</string>
+    <string name="carrier">Carrier</string>
+    <string name="carrier_subtitle">Which engine carries the tunnel</string>
+    <string name="carrier_aether_detail">MASQUE over Cloudflare. The fastest path, and the one everything else here is built around.</string>
+    <string name="carrier_psiphon_detail">Psiphon’s own network. Slower, and someone else’s servers — for networks Aether cannot get out of.</string>
+    <string name="carrier_needs_chain_notice">This build cannot run Psiphon: the routing library it needs is missing.</string>
+    <string name="carrier_whole_device_notice">Psiphon carries the whole device only. Switch Coverage back to Whole device, or choose Aether.</string>
+    <string name="status_starting_carrier">Preparing the carrier…</string>
+    <string name="status_carrier_connecting">Psiphon is looking for a way out. This can take a minute.</string>
+    <string name="status_carrier_carries">Connected through %1$s</string>
+    <string name="err_carrier_whole_device_only">Psiphon cannot run in proxy-only mode</string>
+    <string name="err_carrier_needs_chain">This build cannot route Psiphon: the chain library is missing</string>
+    <string name="err_carrier_failed">Psiphon could not connect</string>
+    <string name="err_carrier_stopped">Psiphon stopped</string>
+    <string name="carrier_not_engine_note">Endpoint, protocol and discovery depth below apply to Aether only. This carrier finds its own way out.</string>
 </resources>

--- a/app/src/test/java/com/whitedns/whiteaesther/core/CarrierConfigTest.kt
+++ b/app/src/test/java/com/whitedns/whiteaesther/core/CarrierConfigTest.kt
@@ -1,0 +1,146 @@
+package com.whitedns.whiteaesther.core
+
+import com.whitedns.whiteaesther.data.Carrier
+import com.whitedns.whiteaesther.data.ChainSettings
+import com.whitedns.whiteaesther.data.ChainSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The configuration mihomo is given when something other than the engine is
+ * carrying the tunnel.
+ *
+ * Every check here is against a failure that would not announce itself. A
+ * carrier config with a missing default route still starts, still reports
+ * connected, and routes the phone's traffic straight onto the local network --
+ * the exact outcome the whole app exists to prevent.
+ */
+class CarrierConfigTest {
+    private val off = ChainSettings(enabled = false)
+
+    @Test
+    fun everythingDefaultsIntoTheCarrier() {
+        val config = ChainConfig.renderCarrier(off, socksPort = 41234)
+
+        assertTrue(
+            config.contains(
+                "- {name: ${ChainConfig.CARRIER_PROXY}, type: socks5, " +
+                    "server: 127.0.0.1, port: 41234, udp: true}",
+            ),
+        )
+        // Last and unconditional. mihomo treats an unmatched connection as
+        // direct, so a config without this is one that carries nothing while
+        // looking like it carries everything.
+        assertTrue(config.trimEnd().endsWith("MATCH,${ChainConfig.EXIT_GROUP}"))
+    }
+
+    @Test
+    fun resolversGoThroughTheCarrierAndNotPastIt() {
+        val config = ChainConfig.renderCarrier(off, socksPort = 41234)
+
+        // A name looked up outside the carrier names the destination to the
+        // network the carrier exists to hide it from -- and here it would be
+        // answered by the interface asking the question.
+        assertTrue(config.contains("https://1.1.1.1/dns-query#${ChainConfig.CARRIER_PROXY}"))
+        assertFalse(config.contains("dns-query#${ChainConfig.TUNNEL_PROXY}"))
+        assertTrue(config.contains("enhanced-mode: fake-ip"))
+    }
+
+    @Test
+    fun aCarrierWithoutUdpRefusesItRatherThanSwallowingIt() {
+        val config = ChainConfig.renderCarrier(off, socksPort = 41234, udp = false)
+
+        assertTrue(config.contains("udp: false"))
+        // Refused, not dropped. A rejected datagram makes a resolver fall back
+        // to TCP within a round trip; one handed to a proxy that cannot carry
+        // it is silence, and every request waits out a timeout instead.
+        assertTrue(config.contains("NETWORK,udp,REJECT"))
+        // Before the default route, or the default route claims it first.
+        val reject = config.indexOf("NETWORK,udp,REJECT")
+        val match = config.indexOf("MATCH,${ChainConfig.EXIT_GROUP}")
+        assertTrue(reject in 1 until match)
+    }
+
+    @Test
+    fun aCarrierWithUdpSaysNothingAboutIt() {
+        val config = ChainConfig.renderCarrier(off, socksPort = 41234, udp = true)
+
+        assertTrue(config.contains("udp: true"))
+        assertFalse(config.contains("NETWORK,udp,REJECT"))
+    }
+
+    @Test
+    fun theUsersOwnRulesSurviveAChangeOfCarrier() {
+        val settings = ChainSettings(
+            enabled = false,
+            routeBlock = "ads.example",
+            routeDirect = "bank.example",
+        )
+        val config = ChainConfig.renderCarrier(settings, socksPort = 41234)
+
+        assertTrue(config.contains("DOMAIN-SUFFIX,ads.example,REJECT"))
+        assertTrue(config.contains("DOMAIN-SUFFIX,bank.example,DIRECT"))
+        // Refusals first: a blocked destination that also matches a direct rule
+        // must stay blocked rather than being dialled anyway.
+        assertTrue(config.indexOf("REJECT") < config.indexOf("DIRECT"))
+    }
+
+    @Test
+    fun anExitChainOverACarrierDialsItsNodesThroughTheCarrier() {
+        val settings = ChainSettings(
+            enabled = true,
+            sources = listOf(ChainSource("Test", "https://example.invalid/sub", true)),
+        )
+        val config = ChainConfig.render(
+            settings,
+            socksPort = 41234,
+            proxyName = ChainConfig.CARRIER_PROXY,
+        )
+
+        // The whole point of the name being a parameter: a user who has set up
+        // an exit chain keeps it when they change carrier, and every node is
+        // dialled through the new one rather than straight off the network.
+        assertTrue(config.contains("dialer-proxy: ${ChainConfig.CARRIER_PROXY}"))
+        assertFalse(config.contains("dialer-proxy: ${ChainConfig.TUNNEL_PROXY}"))
+    }
+
+    @Test
+    fun theEngineKeepsItsOwnNameWhenNothingAsksOtherwise() {
+        val settings = ChainSettings(
+            enabled = true,
+            sources = listOf(ChainSource("Test", "https://example.invalid/sub", true)),
+        )
+        val config = ChainConfig.render(settings, socksPort = 1819)
+
+        assertTrue(config.contains("dialer-proxy: ${ChainConfig.TUNNEL_PROXY}"))
+    }
+
+    @Test
+    fun onlyTheEngineUsesTheEngine() {
+        assertTrue(Carrier.AETHER.usesEngine)
+        assertFalse(Carrier.AETHER.needsChain)
+        Carrier.entries.filter { it != Carrier.AETHER }.forEach { carrier ->
+            assertFalse(carrier.usesEngine)
+            // Nothing but mihomo in this build can turn an interface into
+            // connections, so a carrier that is not the engine cannot run
+            // without it. A carrier added later that forgets this is one that
+            // comes up and carries nothing.
+            assertTrue(carrier.needsChain)
+        }
+    }
+
+    @Test
+    fun carrierWireNamesAreStableAndDistinct() {
+        // The wire name crosses a process boundary on an intent and is written
+        // to preferences that outlive an upgrade. Renaming one silently sends a
+        // restarted session to the wrong carrier.
+        assertEquals("aether", Carrier.AETHER.wireName)
+        assertEquals("psiphon", Carrier.PSIPHON.wireName)
+        assertEquals(
+            Carrier.entries.size,
+            Carrier.entries.map { it.wireName }.distinct().size,
+        )
+    }
+}

--- a/native/psiphon/README.md
+++ b/native/psiphon/README.md
@@ -1,0 +1,69 @@
+# Psiphon carrier
+
+Psiphon as an alternative to the Aether engine: it finds its own way out of a
+network, and mihomo routes the interface into the SOCKS5 listener it produces.
+
+```powershell
+pwsh -File native/psiphon/setup.ps1     # fetch the embedded server list
+```
+
+Nothing else to build. The tunnel core arrives as `ca.psiphon:psiphontunnel`
+from Psiphon's own maven distribution, pinned in `app/build.gradle.kts` and
+scoped to that group alone in `settings.gradle.kts`.
+
+## Its own process, deliberately
+
+`PsiphonService` is declared `android:process=":psiphon"`. Go supports one
+runtime per process, and this process already spends its one on mihomo -- two
+`-buildmode=c-shared` libraries export the same runtime symbols into a single
+linker namespace, and a call binding to the wrong copy enters a runtime that has
+never heard of the calling goroutine.
+
+The cost is an IPC hop carrying two integers and a string. The alternative was
+merging psiphon-tunnel-core into the FlClash module so there is one Go library
+again, which is a dependency-resolution problem between two large trees that
+both vendor quic-go.
+
+## Why it cannot leak
+
+Psiphon's own sockets have to leave by the physical network. `protect()` is no
+help: it acts on a descriptor in the calling process and these are in another
+one. What holds instead is that both processes share a uid and the interface is
+built with `addDisallowedApplication(packageName)` -- `applySplitTunnel` is
+called with `excludeSelf = true` on every path a carrier takes, because a
+carrier always routes through mihomo.
+
+Whole-device only. In proxy mode the listener applications are pointed at is
+ours, with its own port validation and LAN rules, and Psiphon's is neither --
+`runCarrierSession` refuses rather than substituting it.
+
+## The server list
+
+`app/src/main/assets/psiphon_server_entries.txt` is the bootstrap list, one
+hex-encoded server entry per line. It is fetched by `setup.ps1` at a pinned
+revision and checked against a SHA-256, and it is gitignored for the same
+reasons `native/chain/third_party` is: large, regenerable, not ours.
+
+A build without it produces an app whose Psiphon carrier reports the list
+missing at connect time rather than one that spends two minutes dialling
+nothing. Psiphon replaces the list from inside the tunnel once a connection is
+up, so it goes stale the way a phone book does rather than the way a key does.
+
+## The identifiers
+
+`PropagationChannelId` and `SponsorId` say who distributed a client so Psiphon
+can attribute usage and plan capacity. Real ones are issued by Psiphon Inc. to
+partners. `PsiphonConfig` uses the all-Fs and all-1s placeholders that appear
+throughout tunnel-core's own tests and in open-source clients that have not
+asked for a channel of their own.
+
+They are not credentials and nothing is authenticated by them. What they cost is
+that our sessions are indistinguishable from every other unattributed client. If
+this carrier turns out to matter to the people using it, asking Psiphon for a
+channel is the next step, and it is a conversation rather than a patch.
+
+## Licence
+
+psiphon-tunnel-core is GPL-3.0. This app is AGPL-3.0 and section 13 permits the
+combination; the notice obligation is real and is met in
+`THIRD_PARTY_NOTICES.md`.

--- a/native/psiphon/setup.ps1
+++ b/native/psiphon/setup.ps1
@@ -1,0 +1,64 @@
+# Fetches the embedded Psiphon server list into the app's assets.
+#
+#   pwsh -File native/psiphon/setup.ps1 [-Force]
+#
+# Not committed, for the same three reasons native/chain/third_party is not: it
+# is large, it is regenerable, and it is not ours. The build packages whatever it
+# finds; a build without it produces an app whose Psiphon carrier reports itself
+# unavailable rather than one that fails at connect time on a user's phone.
+
+param([switch]$Force)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$root = Split-Path -Parent (Split-Path -Parent $here)
+$dest = Join-Path $root 'app/src/main/assets/psiphon_server_entries.txt'
+
+# What this file is: one hex-encoded Psiphon server entry per line, which is the
+# format psiphon-tunnel-core's startTunneling takes as its embedded bootstrap
+# list. Psiphon replaces it from inside the tunnel once a connection is up, so
+# it goes stale in the way a phone book does rather than in the way a key does.
+#
+# Where it comes from: pinned to a revision, not a branch. A branch tip is not an
+# answer to "which list is in this APK", and this one reaches the network on
+# first connect.
+$Repo   = 'mbm110/MSN-GUARD'
+$Rev    = 'a6379f5d060bc7ca48a4c4ee015648afc8c07a05'
+$Path   = 'app/src/main/assets/server_entries.txt'
+$Sha256 = '6d6d10c4ef8eaf656cb9614513568f40d5590477fc25215507517d51fc6a293e'
+
+if ((Test-Path $dest) -and -not $Force) {
+    $have = (Get-FileHash $dest -Algorithm SHA256).Hash.ToLower()
+    if ($have -eq $Sha256) {
+        Write-Host "server list already present and matches the pin" -ForegroundColor Cyan
+        exit 0
+    }
+    Write-Host "server list present but does not match the pin; replacing" -ForegroundColor Yellow
+}
+
+New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+$url = "https://raw.githubusercontent.com/$Repo/$Rev/$Path"
+Write-Host "fetching the embedded server list..." -ForegroundColor Cyan
+$tmp = "$dest.part"
+Invoke-WebRequest -Uri $url -OutFile $tmp -UseBasicParsing
+
+# Checked before it is moved into place, so a truncated or substituted download
+# never becomes the list a client bootstraps from. Every entry is signed and
+# verified by tunnel-core itself, but a wrong file here is still an app that
+# spends its first minute dialling nothing.
+$have = (Get-FileHash $tmp -Algorithm SHA256).Hash.ToLower()
+if ($have -ne $Sha256) {
+    Remove-Item $tmp -Force
+    throw "server list checksum mismatch: expected $Sha256, got $have"
+}
+
+# One line that is not hex is a file that is not this format -- an HTML error
+# page saved with a 200, most likely -- and tunnel-core would reject the lot
+# without saying which line lost it.
+$bad = Select-String -Path $tmp -Pattern '^[0-9a-fA-F]+$' -NotMatch | Select-Object -First 1
+if ($bad) { Remove-Item $tmp -Force; throw "server list is not hex at line $($bad.LineNumber)" }
+
+Move-Item $tmp $dest -Force
+$kb = [math]::Round((Get-Item $dest).Length / 1KB)
+$lines = (Get-Content $dest | Measure-Object -Line).Lines
+Write-Host "  -> app/src/main/assets/psiphon_server_entries.txt  ($kb KB, $lines entries)" -ForegroundColor Green

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,18 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // Psiphon's own binary distribution. It is a maven layout served out of
+        // a git repository rather than a repository manager, which is how
+        // Psiphon publish it -- see MobileLibrary/Android in psiphon-tunnel-core.
+        //
+        // Scoped to their group alone. A repository this far outside the usual
+        // supply chain has no business being asked for anything else, and an
+        // unscoped one would be consulted for every dependency we resolve.
+        maven {
+            name = "psiphon"
+            url = uri("https://raw.githubusercontent.com/Psiphon-Labs/psiphon-tunnel-core-Android-library/master")
+            content { includeGroup("ca.psiphon") }
+        }
     }
 }
 


### PR DESCRIPTION
A second carrier, chosen under **Routes**. Aether stays the default and the engine
path is untouched.

## What it is

Psiphon runs in its own process and produces a SOCKS5 listener on loopback; mihomo
takes the interface and routes everything into it. `Carrier` is a separate axis from
`TunnelProtocol` on purpose — every member of that enum answers questions about
Cloudflare endpoints, and Psiphon answers none of them.

An exit chain set up by the user survives the change of carrier: the chain's proxy
name is a parameter now, so nodes are dialled through Psiphon exactly as they were
through the engine.

## Why a separate process

Go supports one runtime per process and this one already spends it on mihomo. Two
`-buildmode=c-shared` libraries export the same runtime symbols into one linker
namespace, and the first call to bind to the wrong copy enters a runtime that has
never heard of the calling goroutine. The cost is an IPC hop carrying two integers.

`protect()` cannot reach a socket in another process, so what keeps Psiphon's own
traffic out of the tunnel it is building is that both processes share a uid and the
interface excludes this package — unconditional on the chain path every carrier takes.

## Build

Two things Gradle does not do for you:

```powershell
pwsh -File native/chain/setup.ps1 ; pwsh -File native/chain/build.ps1
pwsh -File native/psiphon/setup.ps1
```

CI and the release workflow now run the second one and then verify that both
`libgojni.so` and `assets/psiphon_server_entries.txt` actually reached each APK.

## Verified

On an x86_64 emulator, API 36: Psiphon establishes (QUIC-OSSH / meek, exit in SG),
reports its port, mihomo takes the interface, answers DNS by fake-ip and routes by
rule, and a request made through Psiphon's own listener returns. Unit tests, lint and
the instrumentation suite pass — 81 tests, the two failures on that emulator are
pre-existing on `main` and unrelated.

**Not verified:** traffic completing across the tun. mihomo does not carry it on that
emulator with the engine either, so that is a physical-device test and it is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)