### PR TITLE
Tor as a third carrier, smaller APKs, and the exit address a carrier session reports

### DIFF
--- a/.github/actions/android-toolchain/action.yml
+++ b/.github/actions/android-toolchain/action.yml
@@ -33,6 +33,7 @@ runs:
         set -o pipefail
         sdkmanager \
           "platforms;android-36" \
+          "platforms;android-37.2" \
           "build-tools;36.0.0" \
           "platform-tools" \
           "ndk;29.0.14206865" \

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ handshake against them, and only accepts a route once real traffic returns
 through it. The app then either raises an Android `VpnService` tunnel that
 captures IPv4, IPv6 and DNS, or exposes a loopback SOCKS5 proxy.
 
-- **Carrier** — Aether by default. Under **Routes**, Psiphon can carry the
-  tunnel instead: it finds its own way out and the app routes the whole device
-  into it. Slower, and someone else's network, so it is there for the networks
-  Aether cannot get out of rather than as an equal choice
+- **Carrier** — Aether by default. Under **Routes**, Psiphon or Tor can carry
+  the tunnel instead: each finds its own way out and the app routes the whole
+  device into it. Both are slower, and one of them is someone else's network, so
+  they are there for the networks Aether cannot get out of rather than as equal
+  choices. Tor carries no UDP, which the app declares rather than discovers
 - **Transports** — MASQUE over HTTP/3 (QUIC) and HTTP/2 (TLS over TCP, for
   networks that block UDP)
 - **Obfuscation** — padding profiles that make tunnel traffic harder to

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -84,6 +84,22 @@ code, and tunnel-core verifies every entry itself.
 own sample configuration, not a channel issued to this app. See
 `native/psiphon/README.md`.
 
+## tor — BSD-3-Clause, via Guardian Project
+
+The Tor carrier is [`info.guardianproject:tor-android:0.4.9.11`](https://github.com/guardianproject/tor-android),
+Guardian Project's Android build of [tor](https://gitlab.torproject.org/tpo/core/tor)
+0.4.9.11 — the same build Orbot uses — together with
+`info.guardianproject:jtorctl:0.4.5.7` for its control protocol. Both come from
+Maven Central and neither is modified.
+
+tor is BSD-3-Clause and both wrappers are BSD-3-Clause. Shipped inside the APK
+as `libtor.so`.
+
+Its pluggable transports are not here. IPtProxy is the obvious way to get them
+and it cannot be used alongside Psiphon: both are gomobile libraries, so both
+ship `libgojni.so` and the `go.*` support classes, and one of the two would
+silently win at packaging time. See `native/tor/README.md`.
+
 ## mihomo, and this combination
 
 Both GPL-3.0 components above are combined with this AGPL-3.0 app under

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,21 @@ android {
     }
 
     packaging {
+        // Compressed in the APK, and extracted at install.
+        //
+        // AGP's default since minSdk 23 is the opposite: store every .so
+        // uncompressed and page-aligned so the loader can map it straight out
+        // of the APK. That trade is right for an app people download from a
+        // store over wifi, and wrong for this one. Three native engines --
+        // mihomo, Psiphon and Aether -- come to about 82MB, and stored
+        // uncompressed that is the download. They deflate better than 3:1.
+        //
+        // What it costs is disk on the device, because the extracted copies sit
+        // beside the APK that still holds them, and a few seconds at install.
+        // What it buys is the download, over a mobile connection, in a country
+        // where that is metered and slow, for an app that is often fetched
+        // again after every block. That is not a close call.
+        jniLibs.useLegacyPackaging = true
         jniLibs.excludes += setOf(
             "**/libboringtun-*.so",
             "**/libquiche.so",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,11 @@ plugins {
 
 android {
     namespace = "com.whitedns.whiteaesther"
-    compileSdk = 36
+    // 37 because tor-android requires it, and only for compiling:
+    // targetSdk stays at 36 deliberately. Raising that is a behaviour
+    // change for every permission and background rule in the app, and it
+    // is not something to carry in on the back of a dependency bump.
+    compileSdk = 37
     ndkVersion = "29.0.14206865"
 
     defaultConfig {
@@ -177,6 +181,22 @@ dependencies {
     // because it is Go, and the exit chain is already the one Go runtime this
     // process is allowed to have.
     implementation("ca.psiphon:psiphontunnel:2.0.41")
+
+    // Tor, as a third carrier. Guardian Project's build, which is Orbot's,
+    // rather than a cross-compile of our own: tor needs openssl, libevent and
+    // zlib built for every ABI, and that is a job somebody already does
+    // properly. It is C, and runs in ":tor" for isolation rather than because
+    // it has to.
+    //
+    // Its pluggable transports are deliberately not here. IPtProxy is the
+    // obvious dependency and it cannot be used: it is a gomobile library, so it
+    // ships `libgojni.so` and the `go.*` support classes -- and so does
+    // Psiphon. Two of them in one APK is a duplicate-class failure at build
+    // time and, worse, one `libgojni.so` silently winning over the other at
+    // packaging time. The transports come as their own executables instead, in
+    // native/tor, which is also how tor expects to launch them.
+    implementation("info.guardianproject:tor-android:0.4.9.11")
+    implementation("info.guardianproject:jtorctl:0.4.5.7")
 
     implementation("androidx.compose.ui:ui:1.11.4")
     implementation("androidx.compose.ui:ui-tooling-preview:1.11.4")

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/service/PsiphonSessionTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/service/PsiphonSessionTest.kt
@@ -1,6 +1,7 @@
 package com.whitedns.whiteaesther.service
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.whitedns.whiteaesther.data.AddressReporter
 import com.whitedns.whiteaesther.data.AppSettings
 import com.whitedns.whiteaesther.data.Carrier
 import com.whitedns.whiteaesther.data.ChainSettings
@@ -8,9 +9,11 @@ import com.whitedns.whiteaesther.data.EngineMode
 import org.junit.After
 import org.junit.Before
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeTrue
 import android.util.Log
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import java.net.InetSocketAddress
 import java.net.Proxy
@@ -181,6 +184,41 @@ class PsiphonSessionTest {
 
         assertTrue("psiphon returned nothing for a plain request", body.isNotBlank())
         EngineLog.record(LogLevel.INFO, "carrier", "psiphon exits at $body")
+    }
+
+    @Test
+    fun theExitAddressReportedIsTheCarriersAndNotThePhonesOwn() {
+        assumeTrue("no psiphon argument, skipping the live carrier test", requested)
+
+        val settings = AppSettings(mode = EngineMode.TUN, carrier = Carrier.PSIPHON)
+        AetherVpnService.start(
+            context,
+            settings.toNativeJson(context),
+            settings.chainForService().encode(),
+            carrier = Carrier.PSIPHON,
+        )
+        assertEquals(
+            EngineStage.CONNECTED,
+            awaitStage(EngineStage.CONNECTED, timeoutMs = 180_000),
+        )
+
+        val port = EngineStatusStore.status.value.carrierSocksPort
+        assertTrue("the session did not publish the carrier's port", (port ?: 0) > 0)
+
+        // The bug this exists for: everything this process opens is excluded
+        // from the interface, so the ordinary "what does the internet see"
+        // lookup leaves by the physical network and answers with the address
+        // the tunnel is there to hide -- displayed under a heading that says
+        // the opposite. The two must not agree.
+        val throughCarrier = runBlocking { AddressReporter.carrierAddress(port!!) }
+        val fromThisProcess = runBlocking { AddressReporter.tunnelAddress(ipv4Only = true) }
+        assertTrue("no address came back through the carrier", !throughCarrier.isNullOrBlank())
+        assertNotEquals(
+            "the reported exit is this phone's own address",
+            fromThisProcess,
+            throughCarrier,
+        )
+        Log.i("carrier-diag", "carrier exit $throughCarrier, this process $fromThisProcess")
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -139,5 +139,31 @@
             android:process=":psiphon"
             android:exported="false" />
 
+        <!--
+          Tor, and the service that drives it, in one process of their own.
+
+          tor is C and has no Go runtime to collide with mihomo's, so unlike
+          Psiphon this is not forced. It is still right: tor is loaded through a
+          JNI library with process-wide static state and a lock, so a failure in
+          it should take down something restartable rather than the process
+          holding the interface.
+
+          TorService is Guardian Project's and arrives from its own manifest,
+          which is why android:process is a replacement rather than a plain
+          attribute: the merger has to be told which of the two declarations
+          wins.
+        -->
+        <service
+            android:name=".service.TorCarrierService"
+            android:process=":tor"
+            android:exported="false" />
+
+        <service
+            android:name="org.torproject.jni.TorService"
+            android:process=":tor"
+            android:exported="false"
+            tools:node="merge"
+            tools:replace="android:process" />
+
     </application>
 </manifest>

--- a/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
@@ -251,10 +251,19 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                             // network and reports the address the tunnel exists
                             // to hide. It said "seen by websites" over the
                             // user's real IP.
-                            val exit = if (chainCarriesTraffic()) {
-                                null
-                            } else {
-                                AddressReporter.tunnelAddress(ipv4Only())
+                            val carrierPort = EngineStatusStore.status.value.carrierSocksPort
+                            val exit = when {
+                                // The chain's node is the exit, and nothing
+                                // reachable from this process can measure it.
+                                chainCarriesTraffic() -> null
+                                // A carrier, asked through its own listener.
+                                // Measuring it the ordinary way reports this
+                                // phone's address under a heading that says the
+                                // opposite, because this process is excluded
+                                // from the interface on purpose -- which is
+                                // exactly what it did before this existed.
+                                carrierPort != null -> AddressReporter.carrierAddress(carrierPort)
+                                else -> AddressReporter.tunnelAddress(ipv4Only())
                             }
                             mutableAddresses.value = mutableAddresses.value.copy(tunnel = exit)
                             // Only here. Asking GitHub from an unprotected

--- a/app/src/main/java/com/whitedns/whiteaesther/core/CarrierClient.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/CarrierClient.kt
@@ -1,0 +1,44 @@
+package com.whitedns.whiteaesther.core
+
+import kotlinx.coroutines.flow.StateFlow
+
+/** How far along a carrier is. */
+enum class CarrierStage { STOPPED, CONNECTING, CONNECTED, FAILED }
+
+/**
+ * What a carrier's process is doing, as seen from this one.
+ *
+ * [port] can be set before [stage] reaches CONNECTED: a listener exists before
+ * the tunnel behind it does, and the two are separate because routing into a
+ * listener with nothing behind it drops traffic rather than refusing it.
+ */
+data class CarrierSnapshot(
+    val stage: CarrierStage = CarrierStage.STOPPED,
+    val port: Int = 0,
+    val failure: String? = null,
+)
+
+/**
+ * A carrier that is not the engine.
+ *
+ * Every one of them is the same shape from the service's point of view: it runs
+ * somewhere else, it takes a while, and what it finally produces is a SOCKS5
+ * port on loopback for mihomo to route the interface into. The differences --
+ * which process, which library, whether it can carry a datagram -- belong to the
+ * implementations and to [com.whitedns.whiteaesther.data.Carrier], not to the
+ * session that uses one.
+ */
+interface CarrierClient {
+    val state: StateFlow<CarrierSnapshot>
+
+    /**
+     * Starts the carrier and waits for a usable tunnel.
+     *
+     * @return the loopback SOCKS5 port, or a failure describing why there is
+     *   none. A timeout is a failure rather than a port that might work later:
+     *   the caller is about to route an interface into this.
+     */
+    suspend fun start(timeoutMs: Long): Result<Int>
+
+    fun stop()
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/core/PsiphonClient.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/PsiphonClient.kt
@@ -15,19 +15,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
- * What the Psiphon process is doing, as seen from this one.
- *
- * [port] is set as soon as the listener exists, which is before the tunnel is
- * established -- the two are separate because routing into a listener with no
- * tunnel behind it is a way to drop traffic silently.
- */
-data class PsiphonState(
-    val state: PsiphonService.State = PsiphonService.State.STOPPED,
-    val port: Int = 0,
-    val failure: String? = null,
-)
-
-/**
  * The near side of [PsiphonService].
  *
  * Binding rather than broadcasting, for two reasons that both matter here. A
@@ -38,9 +25,9 @@ data class PsiphonState(
  * cannot be missed by a client that was not listening yet: the service answers
  * a registration with the current state rather than only the next one.
  */
-class PsiphonClient(private val context: Context) {
-    private val mutableState = MutableStateFlow(PsiphonState())
-    val state = mutableState
+class PsiphonClient(private val context: Context) : CarrierClient {
+    private val mutableState = MutableStateFlow(CarrierSnapshot())
+    override val state = mutableState
 
     private var outgoing: Messenger? = null
     private var connection: ServiceConnection? = null
@@ -52,10 +39,15 @@ class PsiphonClient(private val context: Context) {
                     super.handleMessage(message)
                     return
                 }
-                val state = PsiphonService.State.entries
+                val reported = PsiphonService.State.entries
                     .getOrElse(message.arg1) { PsiphonService.State.STOPPED }
-                mutableState.value = PsiphonState(
-                    state = state,
+                mutableState.value = CarrierSnapshot(
+                    stage = when (reported) {
+                        PsiphonService.State.STOPPED -> CarrierStage.STOPPED
+                        PsiphonService.State.CONNECTING -> CarrierStage.CONNECTING
+                        PsiphonService.State.CONNECTED -> CarrierStage.CONNECTED
+                        PsiphonService.State.FAILED -> CarrierStage.FAILED
+                    },
                     port = message.arg2,
                     failure = message.peekData()?.getString(PsiphonService.EXTRA_FAILURE),
                 )
@@ -72,19 +64,23 @@ class PsiphonClient(private val context: Context) {
      *   and a proxy with no tunnel behind it swallows packets rather than
      *   refusing them.
      */
-    suspend fun start(egressRegion: String, timeoutMs: Long): Result<Int> {
+    override suspend fun start(timeoutMs: Long): Result<Int> {
         bind()
         context.startService(
             Intent(context, PsiphonService::class.java)
                 .setAction(PsiphonService.ACTION_START)
-                .putExtra(PsiphonService.EXTRA_REGION, egressRegion),
+                // Whichever exit Psiphon considers best. Their own client
+                // treats a region as a preference and fails rather than
+                // substituting when it cannot be had, so offering one here
+                // would be offering a way to make the carrier stop working.
+                .putExtra(PsiphonService.EXTRA_REGION, ""),
         )
 
         val settled = withTimeoutOrNull(timeoutMs) {
             mutableState.first { snapshot ->
-                when (snapshot.state) {
-                    PsiphonService.State.CONNECTED -> snapshot.port > 0
-                    PsiphonService.State.FAILED -> true
+                when (snapshot.stage) {
+                    CarrierStage.CONNECTED -> snapshot.port > 0
+                    CarrierStage.FAILED -> true
                     // STOPPED is the state before the service has answered as
                     // much as it is the state after it gives up, so it is not
                     // an outcome on its own.
@@ -97,21 +93,21 @@ class PsiphonClient(private val context: Context) {
             settled == null -> Result.failure(
                 IllegalStateException("Psiphon did not connect in ${timeoutMs / 1000}s"),
             )
-            settled.state == PsiphonService.State.FAILED -> Result.failure(
+            settled.stage == CarrierStage.FAILED -> Result.failure(
                 IllegalStateException(settled.failure ?: "Psiphon failed to start"),
             )
             else -> Result.success(settled.port)
         }
     }
 
-    fun stop() {
+    override fun stop() {
         runCatching {
             context.startService(
                 Intent(context, PsiphonService::class.java).setAction(PsiphonService.ACTION_STOP),
             )
         }
         unbind()
-        mutableState.value = PsiphonState()
+        mutableState.value = CarrierSnapshot()
     }
 
     private suspend fun bind() {
@@ -134,8 +130,8 @@ class PsiphonClient(private val context: Context) {
                 // whatever it last said, because the caller is waiting on a
                 // state that is never going to arrive now.
                 outgoing = null
-                mutableState.value = PsiphonState(
-                    state = PsiphonService.State.FAILED,
+                mutableState.value = CarrierSnapshot(
+                    stage = CarrierStage.FAILED,
                     failure = "The Psiphon process stopped unexpectedly",
                 )
             }

--- a/app/src/main/java/com/whitedns/whiteaesther/core/TorClient.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/TorClient.kt
@@ -1,0 +1,150 @@
+package com.whitedns.whiteaesther.core
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import com.whitedns.whiteaesther.service.TorCarrierService
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * The near side of [TorCarrierService].
+ *
+ * The same arrangement as [PsiphonClient] and for the same reasons: bound
+ * rather than broadcast, so the carrier's process is raised to the importance of
+ * the foreground service holding the interface, and so a client that binds after
+ * the tunnel is already up is told the current state rather than waiting for a
+ * change that has been and gone.
+ */
+class TorClient(private val context: Context) : CarrierClient {
+    private val mutableState = MutableStateFlow(CarrierSnapshot())
+    override val state = mutableState
+
+    private var outgoing: Messenger? = null
+    private var connection: ServiceConnection? = null
+
+    private val incoming = Messenger(
+        object : Handler(Looper.getMainLooper()) {
+            override fun handleMessage(message: Message) {
+                if (message.what != TorCarrierService.MSG_STATE) {
+                    super.handleMessage(message)
+                    return
+                }
+                val reported = TorCarrierService.State.entries
+                    .getOrElse(message.arg1) { TorCarrierService.State.STOPPED }
+                mutableState.value = CarrierSnapshot(
+                    stage = when (reported) {
+                        TorCarrierService.State.STOPPED -> CarrierStage.STOPPED
+                        TorCarrierService.State.CONNECTING -> CarrierStage.CONNECTING
+                        TorCarrierService.State.CONNECTED -> CarrierStage.CONNECTED
+                        TorCarrierService.State.FAILED -> CarrierStage.FAILED
+                    },
+                    port = message.arg2,
+                    failure = message.peekData()?.getString(TorCarrierService.EXTRA_FAILURE),
+                )
+            }
+        },
+    )
+
+    override suspend fun start(timeoutMs: Long): Result<Int> {
+        bind()
+        context.startService(
+            Intent(context, TorCarrierService::class.java)
+                .setAction(TorCarrierService.ACTION_START),
+        )
+
+        val settled = withTimeoutOrNull(timeoutMs) {
+            mutableState.first { snapshot ->
+                when (snapshot.stage) {
+                    CarrierStage.CONNECTED -> snapshot.port > 0
+                    CarrierStage.FAILED -> true
+                    else -> false
+                }
+            }
+        }
+
+        return when {
+            settled == null -> Result.failure(
+                // Named rather than generic, because the usual reason for this
+                // one is not a slow network: it is a network where tor's
+                // directory authorities are unreachable, and without a
+                // pluggable transport there is nothing else for it to try.
+                IllegalStateException("Tor did not build a circuit in ${timeoutMs / 1000}s"),
+            )
+            settled.stage == CarrierStage.FAILED -> Result.failure(
+                IllegalStateException(settled.failure ?: "Tor failed to start"),
+            )
+            else -> Result.success(settled.port)
+        }
+    }
+
+    override fun stop() {
+        runCatching {
+            context.startService(
+                Intent(context, TorCarrierService::class.java)
+                    .setAction(TorCarrierService.ACTION_STOP),
+            )
+        }
+        unbind()
+        mutableState.value = CarrierSnapshot()
+    }
+
+    private suspend fun bind() {
+        if (connection != null) return
+        val established = CompletableDeferred<Unit>()
+        val newConnection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                val messenger = Messenger(binder)
+                outgoing = messenger
+                runCatching {
+                    messenger.send(
+                        Message.obtain(null, TorCarrierService.MSG_REGISTER)
+                            .apply { replyTo = incoming },
+                    )
+                }
+                established.complete(Unit)
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                outgoing = null
+                mutableState.value = CarrierSnapshot(
+                    stage = CarrierStage.FAILED,
+                    failure = "The Tor process stopped unexpectedly",
+                )
+            }
+        }
+        connection = newConnection
+        context.bindService(
+            Intent(context, TorCarrierService::class.java),
+            newConnection,
+            Context.BIND_AUTO_CREATE or Context.BIND_IMPORTANT,
+        )
+        withTimeoutOrNull(BIND_TIMEOUT_MS) { established.await() }
+    }
+
+    private fun unbind() {
+        outgoing?.let { messenger ->
+            runCatching {
+                messenger.send(
+                    Message.obtain(null, TorCarrierService.MSG_UNREGISTER)
+                        .apply { replyTo = incoming },
+                )
+            }
+        }
+        outgoing = null
+        connection?.let { runCatching { context.unbindService(it) } }
+        connection = null
+    }
+
+    private companion object {
+        const val BIND_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/core/TorConfig.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/TorConfig.kt
@@ -1,0 +1,50 @@
+package com.whitedns.whiteaesther.core
+
+/**
+ * The `torrc` this app writes for tor to read.
+ *
+ * Short on purpose. tor's defaults are the product of two decades of people
+ * attacking it, and every line added here is a way this app can be told apart
+ * from every other tor client -- which is the opposite of what tor is for.
+ * What is set is what an app embedding tor has to set, and nothing else.
+ */
+object TorConfig {
+    /**
+     * Country selection is a preference, never a requirement.
+     *
+     * `StrictNodes 0` is the difference between "prefer an exit here" and
+     * "fail if there is not one here". Several countries have a handful of exit
+     * relays and some have none at all, and strict enforcement on those is a
+     * tunnel that never builds -- which a user reads as the app being broken
+     * rather than as the country being empty.
+     */
+    fun render(exitCountry: String?): String = buildString {
+        // Nothing is served, dialled or published by this client.
+        appendLine("SocksPolicy accept 127.0.0.1/8")
+        appendLine("SocksPolicy reject *")
+        // A client, not a relay and not a directory mirror. Explicit because
+        // the defaults are right today and this says they must stay right.
+        appendLine("ClientOnly 1")
+        appendLine("AvoidDiskWrites 1")
+        // The two things this app is not: it never resolves for other apps and
+        // never accepts a connection from off the device.
+        appendLine("DNSPort 0")
+        appendLine("TransPort 0")
+
+        val country = exitCountry?.trim()?.lowercase()?.takeIf { it.length == 2 }
+        if (country != null) {
+            appendLine("ExitNodes {$country}")
+            appendLine("StrictNodes 0")
+        }
+    }
+
+    /**
+     * How long to wait for a circuit before calling it a failure.
+     *
+     * Longer than Psiphon's, because tor is slower to bootstrap by design: it
+     * fetches a consensus, builds a circuit through three relays, and on a
+     * filtered network spends much of that discovering which directory
+     * authorities it can reach at all.
+     */
+    const val BOOTSTRAP_TIMEOUT_MS = 240_000L
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/data/AddressReporter.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/AddressReporter.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.Proxy
 import java.net.URL
 
 /**
@@ -39,6 +41,13 @@ object AddressReporter {
     private const val TRACE_V4 = "https://1.1.1.1/cdn-cgi/trace"
 
     private const val TIMEOUT_MS = 6_000
+
+    /**
+     * Longer than the direct one, because it is three hops rather than none.
+     * Tor in particular answers in its own time, and a timeout short enough for
+     * a local network reads as "no answer" for a circuit that was working.
+     */
+    private const val CARRIER_TIMEOUT_MS = 20_000
 
     private val Context.addressStore by preferencesDataStore(name = "whiteaesther_address")
     private val REAL_ADDRESS = stringPreferencesKey("real_address")
@@ -78,6 +87,40 @@ object AddressReporter {
      * exit while a new one is negotiating would be a confident lie.
      */
     suspend fun tunnelAddress(ipv4Only: Boolean = false): String? = fetch(ipv4Only)
+
+    /**
+     * The address seen from beyond a carrier, asked through the carrier itself.
+     *
+     * [tunnelAddress] cannot answer this. It dials from this process, and this
+     * process is excluded from the interface, so what it measures on a carrier
+     * session is the phone's own address -- reported under a heading that says
+     * the opposite.
+     *
+     * By name rather than by literal, unlike everywhere else here. The address
+     * form is how the direct lookup avoids the resolver choosing IPv6, and it
+     * is exactly wrong through a carrier: Psiphon's servers refuse a port
+     * forward to 1.1.1.1, and a name is resolved at the far end where it also
+     * cannot leak.
+     */
+    suspend fun carrierAddress(socksPort: Int): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", socksPort))
+            val connection = (URL(TRACE_HOST).openConnection(proxy) as HttpURLConnection).apply {
+                connectTimeout = CARRIER_TIMEOUT_MS
+                readTimeout = CARRIER_TIMEOUT_MS
+                requestMethod = "GET"
+                setRequestProperty("User-Agent", "")
+            }
+            try {
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) return@runCatching null
+                connection.inputStream.bufferedReader().useLines { lines ->
+                    lines.firstOrNull { it.startsWith("ip=") }?.removePrefix("ip=")?.trim()
+                }
+            } finally {
+                connection.disconnect()
+            }
+        }.getOrNull()?.takeUnless { it.isNullOrBlank() }
+    }
 
     /**
      * Reads the address, over the family the user chose.

--- a/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
@@ -96,10 +96,32 @@ enum class Carrier(val wireName: String, @StringRes val label: Int) {
      * the process, so Psiphon is loaded somewhere else entirely.
      */
     PSIPHON("psiphon", R.string.carrier_psiphon),
+
+    /**
+     * Tor, in its own process.
+     *
+     * Slower than either of the others and not a general-purpose tunnel: it is
+     * three relays deep by design, and it carries no UDP at all. It is here for
+     * the networks where nothing else gets out, and because what it hides is
+     * different from what the others hide -- an exit relay does not know who
+     * asked.
+     */
+    TOR("tor", R.string.carrier_tor),
     ;
 
     /** True when the Aether engine is in the path at all. */
     val usesEngine: Boolean get() = this == AETHER
+
+    /**
+     * Whether this carrier forwards datagrams.
+     *
+     * Tor does not, and saying so is not a detail. A proxy declared as carrying
+     * UDP that cannot swallows every datagram instead of refusing it, and a
+     * phone experiences that as DNS and QUIC hanging while TCP works -- the
+     * hardest shape of broken to recognise. Declared false, mihomo refuses them
+     * and everything falls back to TCP within a round trip.
+     */
+    val carriesUdp: Boolean get() = this != TOR
 
     /**
      * True when the carrier needs mihomo to reach the interface.

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
@@ -18,7 +18,11 @@ import com.whitedns.whiteaesther.core.ChainController
 import com.whitedns.whiteaesther.core.NativeAetherBridge
 import com.whitedns.whiteaesther.core.NativeEngineListener
 import com.whitedns.whiteaesther.core.NativeSocketProtector
+import com.whitedns.whiteaesther.core.CarrierClient
+import com.whitedns.whiteaesther.core.CarrierStage
 import com.whitedns.whiteaesther.core.PsiphonClient
+import com.whitedns.whiteaesther.core.TorClient
+import com.whitedns.whiteaesther.core.TorConfig
 import com.whitedns.whiteaesther.data.Carrier
 import com.whitedns.whiteaesther.data.ChainSettings
 import com.whitedns.whiteaesther.data.EngineMode
@@ -85,6 +89,21 @@ class AetherVpnService : VpnService() {
     private var carrier: Carrier = Carrier.AETHER
     private val chain by lazy { ChainController(this) }
     private val psiphon by lazy { PsiphonClient(this) }
+    private val tor by lazy { TorClient(this) }
+
+    /**
+     * The carrier this session is using, or null when the engine is.
+     *
+     * Resolved once per session rather than branched on at each use: what
+     * the session does with a carrier is the same whichever one it is, and
+     * a `when` at every call site is a place for the two to drift apart.
+     */
+    private val carrierClient: CarrierClient?
+        get() = when (carrier) {
+            Carrier.AETHER -> null
+            Carrier.PSIPHON -> psiphon
+            Carrier.TOR -> tor
+        }
 
     override fun onCreate() {
         super.onCreate()
@@ -173,7 +192,7 @@ class AetherVpnService : VpnService() {
         dropBlackhole()
         generation += 1
         runCatching { chain.stop() }
-        runCatching { psiphon.stop() }
+        runCatching { stopCarrier() }
         NativeAetherBridge.stop()
         runCatching { NativeAetherBridge.setSocketProtector(null) }
         serviceScope.cancel()
@@ -194,7 +213,7 @@ class AetherVpnService : VpnService() {
                 splitJson = splitSettings
                 NativeAetherBridge.stop()
                 runCatching { chain.stop() }
-                runCatching { psiphon.stop() }
+                runCatching { stopCarrier() }
                 sessionJob?.join()
                 val sessionGeneration = generation
                 sessionJob = serviceScope.launch {
@@ -400,6 +419,33 @@ class AetherVpnService : VpnService() {
      * mihomo with no configuration routes everything DIRECT and a DIRECT route
      * from this process leaves the phone in the clear.
      */
+    /**
+     * Stops every carrier, not merely the current one.
+     *
+     * The setting can change between one session and the next, and the process
+     * that was carrying the last one does not stop merely because nothing is
+     * pointed at it any more. Stopping only [carrierClient] would leave a tunnel
+     * running, and paying for it, behind a session that has moved on.
+     */
+    /**
+     * How long to give this carrier before calling it a failure.
+     *
+     * Not one number for all of them. Psiphon races a dozen protocols and is
+     * either up in seconds or not coming; tor fetches a consensus and builds a
+     * circuit through three relays, and on a filtered network spends most of
+     * that working out which directory authorities it can reach. A timeout set
+     * for the first would report the second broken for working normally.
+     */
+    private fun carrierWaitMs(): Long = when (carrier) {
+        Carrier.TOR -> TorConfig.BOOTSTRAP_TIMEOUT_MS
+        else -> PSIPHON_WAIT_MS
+    }
+
+    private fun stopCarrier() {
+        runCatching { psiphon.stop() }
+        runCatching { tor.stop() }
+    }
+
     private suspend fun runCarrierSession(
         configJson: String,
         mode: EngineMode,
@@ -459,7 +505,7 @@ class AetherVpnService : VpnService() {
         val tunFd = tun.detachFd()
 
         if (sessionGeneration != generation) {
-            runCatching { psiphon.stop() }
+            stopCarrier()
             return
         }
 
@@ -468,17 +514,22 @@ class AetherVpnService : VpnService() {
         )
         updateNotification(mode, sayNow(R.string.status_carrier_connecting))
 
-        val port = psiphon.start("", PSIPHON_WAIT_MS).getOrElse { error ->
+        val client = carrierClient ?: run {
+            reportError(mode, sayNow(R.string.err_carrier_failed))
+            finishIfCurrent(sessionGeneration)
+            return
+        }
+        val port = client.start(carrierWaitMs()).getOrElse { error ->
             val reason = error.message ?: sayNow(R.string.err_carrier_failed)
             EngineLog.record(LogLevel.ERROR, "carrier", reason)
-            runCatching { psiphon.stop() }
+            stopCarrier()
             if (sessionGeneration != generation) return
             scheduleReconnect(configJson, sessionGeneration, mode, reason)
             return
         }
 
         if (sessionGeneration != generation) {
-            runCatching { psiphon.stop() }
+            stopCarrier()
             return
         }
 
@@ -491,17 +542,19 @@ class AetherVpnService : VpnService() {
             chain.startCarrier(
                 settings = chainSettings,
                 socksPort = port,
-                // Psiphon forwards UDP over its own tunnel. The flag exists for
-                // the carriers that do not, where declaring it would make DNS
-                // and QUIC fail silently rather than fall back.
-                udp = true,
+                // Psiphon forwards UDP over its own tunnel; Tor carries none at
+                // all. Declaring it either way is not cosmetic: a proxy that
+                // says it takes datagrams and then drops them makes DNS and
+                // QUIC hang, while one that refuses them makes both fall back
+                // within a round trip.
+                udp = carrier.carriesUdp,
                 tunFd = tunFd,
             )
         }
         if (failure != null) {
             EngineLog.record(LogLevel.ERROR, "chain", failure)
             runCatching { chain.stop() }
-            runCatching { psiphon.stop() }
+            stopCarrier()
             if (sessionGeneration != generation) return
             scheduleReconnect(configJson, sessionGeneration, mode, failure)
             return
@@ -522,15 +575,13 @@ class AetherVpnService : VpnService() {
         // tunnel giving up -- and mihomo would keep the interface up dialling a
         // listener that has gone, which the phone experiences as connected and
         // carrying nothing.
-        psiphon.state.collect { snapshot ->
+        client.state.collect { snapshot ->
             if (sessionGeneration != generation) return@collect
-            if (snapshot.state == PsiphonService.State.FAILED ||
-                snapshot.state == PsiphonService.State.STOPPED
-            ) {
+            if (snapshot.stage == CarrierStage.FAILED || snapshot.stage == CarrierStage.STOPPED) {
                 val reason = snapshot.failure ?: sayNow(R.string.err_carrier_stopped)
                 EngineLog.record(LogLevel.ERROR, "carrier", reason)
                 runCatching { chain.stop() }
-                runCatching { psiphon.stop() }
+                stopCarrier()
                 scheduleReconnect(configJson, sessionGeneration, mode, reason)
                 return@collect
             }

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
@@ -568,7 +568,12 @@ class AetherVpnService : VpnService() {
         }
 
         reconnectAttempt = 0
-        reportConnected(mode, null, sayNow(R.string.status_carrier_carries, sayNow(carrier.label)))
+        reportConnected(
+            mode,
+            null,
+            sayNow(R.string.status_carrier_carries, sayNow(carrier.label)),
+            carrierSocksPort = port,
+        )
 
         // Watched rather than assumed. The carrier is in another process and can
         // be killed on its own -- by the system reclaiming memory, or by its own
@@ -757,7 +762,12 @@ class AetherVpnService : VpnService() {
         else -> LogLevel.INFO
     }
 
-    private fun reportConnected(mode: EngineMode, peer: String?, message: String) {
+    private fun reportConnected(
+        mode: EngineMode,
+        peer: String?,
+        message: String,
+        carrierSocksPort: Int? = null,
+    ) {
         // A working tunnel is the answer to whatever the blocking was for.
         dropBlackhole()
         // The session's byte counting starts here, not when a screen opens, so
@@ -770,6 +780,7 @@ class AetherVpnService : VpnService() {
                 peer,
                 message,
                 connectedAtMillis = System.currentTimeMillis(),
+                carrierSocksPort = carrierSocksPort,
             ),
         )
         updateNotification(mode, message)

--- a/app/src/main/java/com/whitedns/whiteaesther/service/EngineStatus.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/EngineStatus.kt
@@ -28,6 +28,18 @@ data class EngineStatus(
     val message: String = "",
     /** When the tunnel came up, so elapsed time survives the UI being recreated. */
     val connectedAtMillis: Long? = null,
+    /**
+     * The carrier's loopback SOCKS5 port, when a carrier is running.
+     *
+     * Here because of what this process is not allowed to be. Everything it
+     * opens is excluded from the interface -- that exclusion is what keeps the
+     * carrier's own traffic out of the tunnel it is building -- so a request
+     * made from here to ask "what does the internet see" leaves by the physical
+     * network and answers with the address the tunnel exists to hide. Asking
+     * through this port is the only way to get the true answer from inside the
+     * app, and it is the carrier's own listener, so it costs nothing extra.
+     */
+    val carrierSocksPort: Int? = null,
 )
 
 object EngineStatusStore {

--- a/app/src/main/java/com/whitedns/whiteaesther/service/TorCarrierService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/TorCarrierService.kt
@@ -1,0 +1,242 @@
+package com.whitedns.whiteaesther.service
+
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import android.os.RemoteException
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.whitedns.whiteaesther.core.TorConfig
+import org.torproject.jni.TorService
+
+/**
+ * Tor, in a process of its own.
+ *
+ * Unlike Psiphon this one does not have to be here -- tor is C, and a C library
+ * has no runtime to collide with mihomo's. It is here anyway, for two reasons
+ * that will matter more later than they do now. tor is loaded through a JNI
+ * library with a process-wide lock and static state, so a crash in it takes down
+ * whatever process it is in; and its pluggable transports are separate
+ * executables that have to be launched and reaped by whoever owns tor, which is
+ * a job for a process that can be restarted on its own.
+ *
+ * The shape is deliberately the same as [PsiphonService], down to the message
+ * protocol: a carrier is a SOCKS5 listener on loopback and a state, and having
+ * two different shapes for that would be two things to get wrong.
+ *
+ * [TorService] is Guardian Project's, the one Orbot uses. It is declared in this
+ * app's manifest with `android:process` so that it lands here rather than in the
+ * main process, and this service binds it because the port it ends up listening
+ * on is readable only through its binder.
+ */
+class TorCarrierService : android.app.Service() {
+    private val clients = mutableListOf<Messenger>()
+    private var state = State.STOPPED
+    private var socksPort = 0
+    private var failure: String? = null
+
+    private var torService: TorService? = null
+    private var torConnection: ServiceConnection? = null
+    private var started = false
+
+    enum class State { STOPPED, CONNECTING, CONNECTED, FAILED }
+
+    /**
+     * tor's own status, which crosses the process boundary on a plain
+     * broadcast.
+     *
+     * [TorService] sends its status twice -- once through
+     * LocalBroadcastManager, which never leaves the process it was sent from,
+     * and once through the ordinary broadcaster. Only the second one is any use
+     * to a listener that might be elsewhere, and registering for it here rather
+     * than in the app's own process is what keeps the binder-only port lookup
+     * next to the thing that can do it.
+     */
+    private val torStatus = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            when (intent?.getStringExtra(TorService.EXTRA_STATUS)) {
+                TorService.STATUS_ON -> {
+                    // Asked for only now. The port is chosen while tor starts --
+                    // 9050 when it is free and an arbitrary one when it is not --
+                    // and it is not knowable before tor says it is listening.
+                    socksPort = torService?.socksPort ?: 0
+                    if (socksPort > 0) {
+                        state = State.CONNECTED
+                    } else {
+                        state = State.FAILED
+                        failure = "Tor started without a SOCKS listener"
+                    }
+                    broadcast()
+                }
+
+                TorService.STATUS_STARTING -> {
+                    state = State.CONNECTING
+                    broadcast()
+                }
+
+                TorService.STATUS_OFF, TorService.STATUS_STOPPING -> {
+                    // Only meaningful after we asked it to start. TorService
+                    // broadcasts OFF as it is created, which would otherwise be
+                    // read as a tunnel that came up and went away.
+                    if (started && state != State.FAILED) {
+                        state = State.STOPPED
+                        socksPort = 0
+                        broadcast()
+                    }
+                }
+            }
+        }
+    }
+
+    private val handler = object : Handler(Looper.getMainLooper()) {
+        override fun handleMessage(message: Message) {
+            when (message.what) {
+                MSG_REGISTER -> message.replyTo?.let { client ->
+                    clients += client
+                    send(client, stateMessage())
+                }
+                MSG_UNREGISTER -> message.replyTo?.let(clients::remove)
+                else -> super.handleMessage(message)
+            }
+        }
+    }
+
+    private val messenger = Messenger(handler)
+
+    override fun onBind(intent: Intent?): IBinder = messenger.binder
+
+    override fun onCreate() {
+        super.onCreate()
+        ContextCompat.registerReceiver(
+            this,
+            torStatus,
+            IntentFilter(TorService.ACTION_STATUS),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> start(intent.getStringExtra(EXTRA_COUNTRY))
+            ACTION_STOP -> {
+                stopTor()
+                stopSelf()
+                return START_NOT_STICKY
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        stopTor()
+        runCatching { unregisterReceiver(torStatus) }
+        super.onDestroy()
+    }
+
+    private fun start(exitCountry: String?) {
+        if (started) return
+        started = true
+        state = State.CONNECTING
+        failure = null
+        socksPort = 0
+        broadcast()
+
+        runCatching {
+            // Written before tor is started, because it is read once at
+            // startup. TorService owns torrc-defaults -- that is where the
+            // SOCKS port lands -- so this is the file for everything else.
+            TorService.getTorrc(this).writeText(TorConfig.render(exitCountry))
+        }.onFailure { error ->
+            fail("Could not write tor's configuration: ${error.message}")
+            return
+        }
+
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                torService = (binder as? TorService.LocalBinder)?.service
+                // tor may already be listening by the time this binds, in which
+                // case its status broadcast has been and gone and nothing else
+                // will arrive. A port is the same evidence the broadcast
+                // carries, and asking for it costs nothing when there is none.
+                val port = torService?.socksPort ?: 0
+                if (port > 0 && state != State.CONNECTED) {
+                    socksPort = port
+                    state = State.CONNECTED
+                    broadcast()
+                }
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                torService = null
+            }
+        }
+        torConnection = connection
+
+        runCatching {
+            bindService(
+                Intent(this, TorService::class.java),
+                connection,
+                Context.BIND_AUTO_CREATE,
+            )
+        }.onFailure { error ->
+            fail(error.message ?: "Tor did not start")
+        }
+    }
+
+    private fun stopTor() {
+        if (!started) return
+        started = false
+        torConnection?.let { runCatching { unbindService(it) } }
+        torConnection = null
+        torService = null
+        runCatching { stopService(Intent(this, TorService::class.java)) }
+        socksPort = 0
+        if (state != State.FAILED) state = State.STOPPED
+        broadcast()
+    }
+
+    private fun fail(reason: String) {
+        state = State.FAILED
+        failure = reason
+        Log.e("tor", reason)
+        broadcast()
+    }
+
+    private fun stateMessage(): Message = Message.obtain(null, MSG_STATE).apply {
+        arg1 = state.ordinal
+        arg2 = socksPort
+        failure?.let { data = Bundle().apply { putString(EXTRA_FAILURE, it) } }
+    }
+
+    private fun broadcast() {
+        clients.toList().forEach { send(it, stateMessage()) }
+    }
+
+    private fun send(client: Messenger, message: Message) {
+        try {
+            client.send(message)
+        } catch (_: RemoteException) {
+            clients.remove(client)
+        }
+    }
+
+    companion object {
+        const val ACTION_START = "com.whitedns.whiteaesther.TOR_START"
+        const val ACTION_STOP = "com.whitedns.whiteaesther.TOR_STOP"
+        const val EXTRA_COUNTRY = "country"
+        const val EXTRA_FAILURE = "failure"
+
+        const val MSG_REGISTER = 1
+        const val MSG_UNREGISTER = 2
+        const val MSG_STATE = 3
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
@@ -706,6 +706,7 @@ fun RoutesScreen(
                         subtitle = when (carrier) {
                             Carrier.AETHER -> stringResource(R.string.carrier_aether_detail)
                             Carrier.PSIPHON -> stringResource(R.string.carrier_psiphon_detail)
+                            Carrier.TOR -> stringResource(R.string.carrier_tor_detail)
                         },
                         selected = settings.carrier == carrier,
                         // OptionRow tags itself from the title, so this row is

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -467,4 +467,6 @@
     <string name="err_carrier_failed">سایفون نتوانست وصل شود</string>
     <string name="err_carrier_stopped">سایفون متوقف شد</string>
     <string name="carrier_not_engine_note">نقطهٔ پایانی، پروتکل و عمق جست‌وجوی پایین فقط برای اتر هستند. این حامل خودش راه خروجش را پیدا می‌کند.</string>
+    <string name="carrier_tor">تور</string>
+    <string name="carrier_tor_detail">سه رله، و خروجی نمی‌داند چه کسی درخواست کرده. کندترین گزینه، و UDP را حمل نمی‌کند.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -473,4 +473,6 @@
     <string name="err_carrier_failed">Psiphon could not connect</string>
     <string name="err_carrier_stopped">Psiphon stopped</string>
     <string name="carrier_not_engine_note">Endpoint, protocol and discovery depth below apply to Aether only. This carrier finds its own way out.</string>
+    <string name="carrier_tor">Tor</string>
+    <string name="carrier_tor_detail">Three relays, and the exit does not know who asked. The slowest option, and it carries no UDP.</string>
 </resources>

--- a/native/tor/README.md
+++ b/native/tor/README.md
@@ -1,0 +1,66 @@
+# Tor carrier
+
+Tor as an alternative to the Aether engine. It finds its own way out through
+three relays, and mihomo routes the interface into the SOCKS5 listener it
+produces — the same arrangement Psiphon uses, and deliberately the same shape in
+the code.
+
+Nothing to build. tor arrives as `info.guardianproject:tor-android`, Guardian
+Project's Android build and the one Orbot ships, with `jtorctl` for its control
+protocol. Both are pinned in `app/build.gradle.kts`.
+
+It requires `compileSdk 37`. `targetSdk` deliberately stays at 36: raising that
+changes behaviour across every permission and background rule in the app, and it
+is not something to carry in behind a dependency bump.
+
+## Its own process
+
+`TorService` is declared in this app's manifest with `android:process=":tor"`,
+which overrides the library's own declaration, and `TorCarrierService` sits in
+the same process to drive it.
+
+Unlike Psiphon this is not forced — tor is C and has no Go runtime to collide
+with mihomo's. It is still right. tor is loaded through a JNI library with
+process-wide static state and a lock, so a failure in it should take down
+something restartable rather than the process holding the interface. And the
+pluggable transports, when they arrive, are separate executables that have to be
+launched and reaped by whoever owns tor.
+
+## No UDP, declared rather than discovered
+
+Tor carries TCP only. `Carrier.TOR.carriesUdp` is false, and mihomo is
+configured from it: the carrier proxy is declared `udp: false` and a
+`NETWORK,udp,REJECT` rule sits above the default route.
+
+This matters more than it sounds. A proxy declared as carrying datagrams that
+cannot swallows every one of them, and a phone experiences that as DNS and QUIC
+hanging while TCP works — which is the hardest shape of broken to recognise.
+Refused, a resolver falls back to TCP and a browser falls back off QUIC, both
+within a round trip. DNS still resolves because the chain's resolvers are
+DNS-over-HTTPS, which is TCP.
+
+## Pluggable transports are missing, and why
+
+Direct Tor only, for now. Where tor is blocked outright — which is the case this
+carrier is most wanted for — it will not connect.
+
+The obvious dependency is IPtProxy, which packages lyrebird (obfs4, meek,
+webtunnel) and snowflake. It cannot be used here: it is a gomobile library, so
+it ships `libgojni.so` and the `go.*` support classes, and so does Psiphon. Two
+of them in one APK is a duplicate-class failure at build time, and worse, one
+`libgojni.so` quietly winning over the other at packaging time — which would
+break whichever carrier lost, at run time, on a device.
+
+The way in is the way tor itself expects: transports as their own executables,
+launched with `ClientTransportPlugin`. lyrebird and snowflake are ordinary Go
+programs, and a Go program cross-compiled for Android with `-buildmode=pie` and
+shipped in `jniLibs` as `lib*.so` is extracted to `nativeLibraryDir` and can be
+executed from there. That extraction is why `useLegacyPackaging` being on is a
+prerequisite rather than only a size decision.
+
+That build is not written yet.
+
+## Licence
+
+tor is BSD-3-Clause, and so are `tor-android` and `jtorctl`. Recorded in
+`THIRD_PARTY_NOTICES.md`.


### PR DESCRIPTION
Three changes, in that order.

## The APK is a third of the size

The native libraries were stored uncompressed — AGP's default since minSdk 23, so
the loader can map them straight out of the APK. That trade suits an app installed
from a store; ours is sideloaded over metered connections. `useLegacyPackaging = true`
compresses them at better than 3:1. **119MB → 52MB** on an arm64 debug build. All
three libraries were already stripped, so there was nothing else to take.

Verified afterwards that the chain library still loads: it is `dlopen`'d by soname,
which resolves out of the extracted directory exactly as it did out of the APK.

## Tor, direct

Same shape as Psiphon, deliberately: own process, SOCKS5 on loopback, mihomo takes
the interface into it. `CarrierClient` is now the interface both implement, so the
session code no longer knows which carrier it has.

Tor carries no UDP and the app says so rather than finding out — `udp: false` on the
proxy plus a `NETWORK,udp,REJECT` rule above the default route. A proxy that claims
datagrams and drops them makes DNS and QUIC hang while TCP works; refused, both fall
back within a round trip.

`compileSdk` moves to 37 because `tor-android` requires it. `targetSdk` stays at 36.

**The honest limit:** no pluggable transports, so where Tor is blocked outright it will
not connect. IPtProxy is the obvious dependency and cannot be used — it and Psiphon are
both gomobile libraries, both ship `libgojni.so`, and one would silently win at packaging
time. `native/tor/README.md` records the way in: transports as executables under
`ClientTransportPlugin`, which the packaging change above is a prerequisite for.

## The exit address a carrier reports

Reported bug: on a Psiphon session the "seen by websites" row showed the user's own
address, unchanged forever. It was asking from this process, which is excluded from
the interface on purpose, so the answer was the address the tunnel exists to hide.

It is asked through the carrier's own SOCKS listener now. Verified live:
`192.241.210.85` through Psiphon, `119.76.15.180` from this process.

## Verified

Unit tests and lint pass. Instrumentation: 82 tests on an API 36 x86_64 emulator, the
two failures are pre-existing on `main`. The live Psiphon suite passes with
`-Pandroid.testInstrumentationRunnerArguments.psiphon=1`. Tor itself is not yet
exercised on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)