### PR TITLE
Give Tor its bridges, and stop calling it connected before it is

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,16 @@ jobs:
         shell: pwsh
         run: ./native/psiphon/setup.ps1
 
+      # Tor's pluggable transports. Go again, and the same toolchain the chain
+      # step above installed. Without them Tor still runs and only its bridge
+      # modes are unavailable, which is a worse release than it needs to be on
+      # exactly the networks Tor is wanted for.
+      - name: Build the pluggable transports
+        shell: pwsh
+        run: |
+          ./native/tor/setup.ps1
+          ./native/tor/build.ps1
+
       - name: Build signed APKs and bundle
         shell: bash
         run: |
@@ -170,6 +180,12 @@ jobs:
             jar tf "$apk" | grep -F "lib/${abi}/libwhiteaestherchain.so"
             jar tf "$apk" | grep -F "lib/${abi}/libgojni.so"
             jar tf "$apk" | grep -qF "assets/psiphon_server_entries.txt"
+            # Tor and both of its transports. A transport that did not make it
+            # into the APK is a bridge mode that fails on a phone which has
+            # already installed the build.
+            jar tf "$apk" | grep -F "lib/${abi}/libtor.so"
+            jar tf "$apk" | grep -F "lib/${abi}/liblyrebird.so"
+            jar tf "$apk" | grep -F "lib/${abi}/libsnowflake.so"
             test "$(jar tf "$apk" | grep -c '^lib/.*/libwhiteaestherchain\.so$')" -eq 1
             cp "$apk" "release-assets/${base}-${abi}.apk"
           done

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ archive/
 # pinned revision and checked against a SHA-256 -- large, regenerable, and not
 # ours, which is the same reason native/chain/third_party is not committed.
 app/src/main/assets/psiphon_server_entries.txt
+native/tor/third_party/
+native/tor/build/

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ error. It is the first thing to read.
 | What you see | What it means |
 | --- | --- |
 | `... · retry 3 of 8 in 12s` | A path failed and it is trying another. Normal on a hostile network. |
-| `Psiphon is looking for a way out` | The Psiphon carrier is establishing. It tries many protocols at once and a minute is normal. |
+| `... is looking for a way out` | A carrier is establishing. Psiphon tries many protocols at once; Tor fetches a consensus and builds a circuit. A minute is normal, and behind a bridge rather more. |
 | `Stopped after 8 attempts` | Nothing worked here. Try a different profile or network. |
 | `custom endpoint ... failed MASQUE validation` | The address you pinned is not reachable. Switch **Endpoint** back to Automatic. |
 | `Connected to a different endpoint` | Your pinned address failed and fallback substituted a working one. |
@@ -139,11 +139,19 @@ pwsh -File native/chain/setup.ps1
 pwsh -File native/chain/build.ps1
 ```
 
-and Psiphon's bootstrap server list, which is data rather than code and is not
+Psiphon's bootstrap server list, which is data rather than code and is not
 committed:
 
 ```powershell
 pwsh -File native/psiphon/setup.ps1
+```
+
+and Tor's pluggable transports, which are Go programs built as Android
+executables:
+
+```powershell
+pwsh -File native/tor/setup.ps1
+pwsh -File native/tor/build.ps1
 ```
 
 A build missing either still installs and runs; the feature that needs it says

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -95,10 +95,21 @@ Maven Central and neither is modified.
 tor is BSD-3-Clause and both wrappers are BSD-3-Clause. Shipped inside the APK
 as `libtor.so`.
 
-Its pluggable transports are not here. IPtProxy is the obvious way to get them
-and it cannot be used alongside Psiphon: both are gomobile libraries, so both
-ship `libgojni.so` and the `go.*` support classes, and one of the two would
-silently win at packaging time. See `native/tor/README.md`.
+## lyrebird and snowflake — BSD-3-Clause
+
+Tor's pluggable transports, built from source at the revisions pinned in
+`native/tor/setup.ps1`:
+
+- [lyrebird](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird)
+  `lyrebird-0.8.1`, which provides obfs4
+- [snowflake](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake)
+  `v2.14.1`
+
+Both are BSD-3-Clause and neither is modified. They are ordinary Go programs,
+cross-compiled for Android and shipped in the APK as `liblyrebird.so` and
+`libsnowflake.so` — executables named like libraries because that is the only
+form Android extracts and leaves executable. Neither is committed; both are
+fetched and built by `native/tor/setup.ps1` and `native/tor/build.ps1`.
 
 ## mihomo, and this combination
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,6 +156,12 @@ android {
         // chain at run time and reports it unavailable when it is absent, which
         // is what a build without it should do.
         getByName("main").jniLibs.srcDir(rootProject.file("native/chain/build"))
+        // Tor's pluggable transports, built separately by native/tor/build.ps1.
+        // Executables rather than libraries, named lib*.so because that is the
+        // only thing Android extracts and marks executable. Absent, tor still
+        // runs and only its bridge modes are unavailable, which is what a build
+        // without them should do.
+        getByName("main").jniLibs.srcDir(rootProject.file("native/tor/build"))
     }
 }
 

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/service/TorSessionTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/service/TorSessionTest.kt
@@ -1,0 +1,131 @@
+package com.whitedns.whiteaesther.service
+
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import com.whitedns.whiteaesther.data.AddressReporter
+import com.whitedns.whiteaesther.data.AppSettings
+import com.whitedns.whiteaesther.data.Carrier
+import com.whitedns.whiteaesther.data.EngineMode
+import com.whitedns.whiteaesther.data.TorBridge
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Brings the Tor carrier up on a device.
+ *
+ * Live, slow and opt-in. Tor bootstraps a consensus and three relays, and behind
+ * a bridge it does that through one more hop it is still discovering, so this
+ * takes minutes rather than seconds and cannot run anywhere without a way out:
+ *
+ *     -Pandroid.testInstrumentationRunnerArguments.tor=1
+ *
+ * and, because nothing here can tap a dialog:
+ *
+ *     adb shell appops set com.whitedns.whiteaesther ACTIVATE_VPN allow
+ *
+ * `torBridge=obfs4|snowflake|meek` picks a transport; the default is direct.
+ * Direct is the one to run where Tor is not blocked, because it tests the
+ * carrier; a bridge mode is the one to run where it is, because that tests
+ * whether the transports were built and launched at all.
+ */
+class TorSessionTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val requested: Boolean
+        get() = InstrumentationRegistry.getArguments().getString("tor") == "1"
+
+    private val bridge: TorBridge
+        get() = InstrumentationRegistry.getArguments().getString("torBridge")
+            ?.let { name -> TorBridge.entries.firstOrNull { it.wireName == name } }
+            ?: TorBridge.NONE
+
+    @Before
+    fun clearStatus() {
+        AetherVpnService.stop(context)
+        val deadline = System.currentTimeMillis() + 20_000
+        while (System.currentTimeMillis() < deadline &&
+            EngineStatusStore.status.value.stage != EngineStage.IDLE
+        ) {
+            Thread.sleep(500)
+        }
+        // tor holds a process-wide lock while it unwinds, and a second start
+        // before it lets go is refused rather than queued.
+        Thread.sleep(4_000)
+        EngineStatusStore.update(EngineStatus())
+        EngineLog.clear()
+    }
+
+    @After
+    fun tearDown() {
+        AetherVpnService.stop(context)
+    }
+
+    @Test
+    fun torCarriesTheInterfaceAndTheExitIsNotThisPhone() {
+        assumeTrue("no tor argument, skipping the live carrier test", requested)
+
+        val settings = AppSettings(
+            mode = EngineMode.TUN,
+            carrier = Carrier.TOR,
+            torBridge = bridge,
+        )
+        AetherVpnService.start(
+            context,
+            settings.toNativeJson(context),
+            settings.chainForService().encode(),
+            carrier = Carrier.TOR,
+            torBridge = bridge,
+        )
+
+        val stage = awaitStage(EngineStage.CONNECTED, timeoutMs = 420_000)
+        assertEquals(
+            "tor did not carry the interface on ${bridge.wireName}: " +
+                EngineStatusStore.status.value.message,
+            EngineStage.CONNECTED,
+            stage,
+        )
+
+        val port = EngineStatusStore.status.value.carrierSocksPort
+        assertTrue("the session did not publish tor's port", (port ?: 0) > 0)
+
+        // The measurement that says the circuit is real rather than merely
+        // built: an exit relay answers, and it is not this phone. Asked through
+        // tor's own listener because this process is excluded from the
+        // interface on purpose.
+        val throughTor = runBlocking { AddressReporter.carrierAddress(port!!) }
+        val fromThisProcess = runBlocking { AddressReporter.tunnelAddress(ipv4Only = true) }
+        assertTrue("nothing came back through tor", !throughTor.isNullOrBlank())
+        assertNotEquals("the exit is this phone's own address", fromThisProcess, throughTor)
+        Log.i("carrier-diag", "tor(${bridge.wireName}) exits at $throughTor, phone $fromThisProcess")
+
+        assertTrue(
+            "no log from mihomo reached the app",
+            awaitLog("chain", timeoutMs = 20_000),
+        )
+    }
+
+    private fun awaitLog(tag: String, timeoutMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (EngineLog.entries.value.any { it.tag == tag }) return true
+            Thread.sleep(500)
+        }
+        return false
+    }
+
+    private fun awaitStage(target: EngineStage, timeoutMs: Long): EngineStage {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val current = EngineStatusStore.status.value.stage
+            if (current == target || current == EngineStage.ERROR) return current
+            Thread.sleep(500)
+        }
+        return EngineStatusStore.status.value.stage
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
@@ -427,6 +427,7 @@ class MainActivity : ComponentActivity() {
             settings.killSwitch,
             settings.strictKillSwitch,
             settings.carrier,
+            settings.torBridge,
         )
     }
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/core/TorClient.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/TorClient.kt
@@ -9,6 +9,7 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.Message
 import android.os.Messenger
+import com.whitedns.whiteaesther.data.TorBridge
 import com.whitedns.whiteaesther.service.TorCarrierService
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +25,10 @@ import kotlinx.coroutines.withTimeoutOrNull
  * the tunnel is already up is told the current state rather than waiting for a
  * change that has been and gone.
  */
-class TorClient(private val context: Context) : CarrierClient {
+class TorClient(
+    private val context: Context,
+    private val bridge: TorBridge,
+) : CarrierClient {
     private val mutableState = MutableStateFlow(CarrierSnapshot())
     override val state = mutableState
 
@@ -58,7 +62,8 @@ class TorClient(private val context: Context) : CarrierClient {
         bind()
         context.startService(
             Intent(context, TorCarrierService::class.java)
-                .setAction(TorCarrierService.ACTION_START),
+                .setAction(TorCarrierService.ACTION_START)
+                .putExtra(TorCarrierService.EXTRA_BRIDGE, bridge.wireName),
         )
 
         val settled = withTimeoutOrNull(timeoutMs) {

--- a/app/src/main/java/com/whitedns/whiteaesther/core/TorConfig.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/TorConfig.kt
@@ -1,5 +1,7 @@
 package com.whitedns.whiteaesther.core
 
+import com.whitedns.whiteaesther.data.TorBridge
+
 /**
  * The `torrc` this app writes for tor to read.
  *
@@ -10,20 +12,69 @@ package com.whitedns.whiteaesther.core
  */
 object TorConfig {
     /**
-     * Country selection is a preference, never a requirement.
+     * The bridges tor falls back on when the user has not been given any.
      *
-     * `StrictNodes 0` is the difference between "prefer an exit here" and
-     * "fail if there is not one here". Several countries have a handful of exit
-     * relays and some have none at all, and strict enforcement on those is a
-     * tunnel that never builds -- which a user reads as the app being broken
-     * rather than as the country being empty.
+     * These are the lines Tor Browser ships, unchanged. They are public by
+     * design -- a bridge nobody can find is a bridge nobody can use -- and by
+     * the same token they are the first ones a censor blocks. A bridge from
+     * bridges.torproject.org beats every one of them, which is why the screen
+     * says so, but a default that sometimes works beats a field the user has to
+     * fill in before anything happens at all.
+     *
+     * Not fetched at runtime. Asking a server which bridges to use is a request
+     * that names this device to somebody, from an app whose whole purpose is
+     * not to make those.
      */
-    fun render(exitCountry: String?): String = buildString {
+    private val DEFAULT_OBFS4 = listOf(
+        "obfs4 192.95.36.142:443 CDF2E852BF539B82BD10E27E9115A31734E378C2 " +
+            "cert=qUVQ0srL1JI/vO6V6m/24anYXiJD3QP2HgzUKQtQ7GRqqUvs7P+tG43RtAqdhLOALP7DJQ " +
+            "iat-mode=1",
+        "obfs4 37.218.245.14:38224 D9A82D2F9C2F65A18407B1D2B764F130847F8B5D " +
+            "cert=bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg " +
+            "iat-mode=0",
+        "obfs4 85.31.186.98:443 011F2599C0E9B27EE74B353155E244813763C3E5 " +
+            "cert=ayq0XzCwhpdysn5o0EyDUbmSOx3X/oTEbzDMvczHOdBJKlvIdHHLJGkZARtT4dcBFArPPg " +
+            "iat-mode=0",
+    )
+
+    /** One line, and it is the same one every snowflake client uses. */
+    private const val DEFAULT_SNOWFLAKE =
+        "snowflake 192.0.2.3:80 2B280B23E1107BB62ABFC40DDCC8824814F80A72 " +
+            "fingerprint=2B280B23E1107BB62ABFC40DDCC8824814F80A72 " +
+            "url=https://1098762253.rsc.cdn77.org/ " +
+            "fronts=www.cdn77.com,www.phpmyadmin.net " +
+            "ice=stun:stun.l.google.com:19302,stun:stun.antisip.com:3478 " +
+            "utls-imitate=hellorandomizedalpn"
+
+    /** The transport a bridge mode needs, by the name the proxy answers to. */
+    fun transportName(bridge: TorBridge): String? = when (bridge) {
+        TorBridge.NONE -> null
+        TorBridge.OBFS4 -> "obfs4"
+        TorBridge.SNOWFLAKE -> "snowflake"
+    }
+
+    /**
+     * @param transport where the already-running transport is listening, as
+     *   `host:port`, or null when there is none.
+     *
+     * `socks5` rather than `exec`, and not by preference. tor normally launches
+     * a managed proxy itself, but this libtor aborts inside
+     * `pt_parse_transport_line` when told to -- before it has logged a word,
+     * which is what a build without the fork it needs looks like. The identical
+     * torrc with `socks5` starts cleanly, so the proxy is started by
+     * [com.whitedns.whiteaesther.service.PluggableTransport] and tor is handed
+     * the port it ended up on.
+     */
+    fun render(
+        bridge: TorBridge,
+        exitCountry: String?,
+        transport: String?,
+    ): String = buildString {
         // Nothing is served, dialled or published by this client.
         appendLine("SocksPolicy accept 127.0.0.1/8")
         appendLine("SocksPolicy reject *")
-        // A client, not a relay and not a directory mirror. Explicit because
-        // the defaults are right today and this says they must stay right.
+        // A client, not a relay and not a directory mirror. Explicit because the
+        // defaults are right today and this says they must stay right.
         appendLine("ClientOnly 1")
         appendLine("AvoidDiskWrites 1")
         // The two things this app is not: it never resolves for other apps and
@@ -31,20 +82,40 @@ object TorConfig {
         appendLine("DNSPort 0")
         appendLine("TransPort 0")
 
+        val name = transportName(bridge)
+        if (name != null && transport != null) {
+            appendLine("ClientTransportPlugin $name socks5 $transport")
+            appendLine("UseBridges 1")
+            bridgeLines(bridge).forEach { appendLine("Bridge $it") }
+        }
+
         val country = exitCountry?.trim()?.lowercase()?.takeIf { it.length == 2 }
         if (country != null) {
             appendLine("ExitNodes {$country}")
+            // A preference, never a requirement. `StrictNodes 1` on a country
+            // with a handful of exit relays -- or none -- is a tunnel that never
+            // builds, which a user reads as the app being broken rather than as
+            // the country being empty.
             appendLine("StrictNodes 0")
         }
+    }
+
+    internal fun bridgeLines(bridge: TorBridge): List<String> = when (bridge) {
+        TorBridge.NONE -> emptyList()
+        TorBridge.OBFS4 -> DEFAULT_OBFS4
+        TorBridge.SNOWFLAKE -> listOf(DEFAULT_SNOWFLAKE)
     }
 
     /**
      * How long to wait for a circuit before calling it a failure.
      *
      * Longer than Psiphon's, because tor is slower to bootstrap by design: it
-     * fetches a consensus, builds a circuit through three relays, and on a
-     * filtered network spends much of that discovering which directory
-     * authorities it can reach at all.
+     * fetches a consensus and builds a circuit through three relays, and behind
+     * a bridge it does all of that through one more hop that is itself being
+     * discovered.
      */
-    const val BOOTSTRAP_TIMEOUT_MS = 240_000L
+    fun bootstrapTimeoutMs(bridge: TorBridge): Long = when (bridge) {
+        TorBridge.NONE -> 240_000L
+        else -> 300_000L
+    }
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/data/AddressReporter.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/AddressReporter.kt
@@ -43,11 +43,15 @@ object AddressReporter {
     private const val TIMEOUT_MS = 6_000
 
     /**
-     * Longer than the direct one, because it is three hops rather than none.
-     * Tor in particular answers in its own time, and a timeout short enough for
-     * a local network reads as "no answer" for a circuit that was working.
+     * Longer than the direct one, and generously so.
+     *
+     * This is three hops rather than none, and on meek every one of them is a
+     * CDN round trip -- measured at over twenty seconds for a single request on
+     * a working circuit. Nothing waits on this but a row on a screen, so the
+     * cost of being patient is a field that fills in late, and the cost of not
+     * being is a blank one under a tunnel that is working.
      */
-    private const val CARRIER_TIMEOUT_MS = 20_000
+    private const val CARRIER_TIMEOUT_MS = 60_000
 
     private val Context.addressStore by preferencesDataStore(name = "whiteaesther_address")
     private val REAL_ADDRESS = stringPreferencesKey("real_address")

--- a/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
@@ -135,6 +135,31 @@ enum class Carrier(val wireName: String, @StringRes val label: Int) {
     val needsChain: Boolean get() = this != AETHER
 }
 
+/**
+ * How Tor reaches its first hop.
+ *
+ * Ordered by how much they cost and how much they survive, which is the order a
+ * user should try them in. Direct is fastest and blocked wherever Tor is; obfs4
+ * hides the shape of the traffic; snowflake goes through whichever volunteer
+ * browser answers; meek rides a CDN, which is slow and very hard to block
+ * without blocking the CDN.
+ */
+enum class TorBridge(val wireName: String, @StringRes val label: Int) {
+    NONE("none", R.string.tor_bridge_none),
+    OBFS4("obfs4", R.string.tor_bridge_obfs4),
+    SNOWFLAKE("snowflake", R.string.tor_bridge_snowflake),
+    // meek is deliberately absent. lyrebird starts it and tor accepts it, and
+    // then it never finishes bootstrapping -- seven minutes on the public
+    // bridge, repeatedly, while obfs4 and snowflake took under a minute from
+    // the same network. Offering it would be offering a mode that hangs and
+    // then fails. The plumbing is generic, so it is a two-line change to bring
+    // back when there is a bridge worth pointing at.
+    ;
+
+    /** True when this needs a transport executable that a build may not ship. */
+    val needsTransports: Boolean get() = this != NONE
+}
+
 /** Protocols sharing one set of endpoints, so an address found on one fits the other. */
 enum class EndpointFamily {
     MASQUE,
@@ -234,6 +259,16 @@ data class AppSettings(
      * slower, and one of them is somebody else's network.
      */
     val carrier: Carrier = Carrier.AETHER,
+    /**
+     * How Tor reaches its first hop, when Tor is the carrier.
+     *
+     * Direct by default, which is both the fastest and the one that fails on
+     * exactly the networks this carrier is wanted for. Defaulting to a bridge
+     * instead would make every user pay for a hop most of them do not need, and
+     * would put the app's traffic on three well-known public bridges that are
+     * blocked in the places a bridge is required.
+     */
+    val torBridge: TorBridge = TorBridge.NONE,
     // Automatic, because the answer depends on the network and the user has no
     // way to know it. A fixed default of H3 meant every install on a network
     // that blocks UDP spent minutes failing before anything else was tried.

--- a/app/src/main/java/com/whitedns/whiteaesther/data/SettingsRepository.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/SettingsRepository.kt
@@ -19,6 +19,7 @@ class SettingsRepository(private val context: Context) {
             proxyPort = preferences[PROXY_PORT]?.coerceIn(1_024, 65_535) ?: 1819,
             transport = enumValueOrDefault(preferences[TRANSPORT], TunnelProtocol.AUTO),
             carrier = enumValueOrDefault(preferences[CARRIER], Carrier.AETHER),
+            torBridge = enumValueOrDefault(preferences[TOR_BRIDGE], TorBridge.NONE),
             scanStrategy = enumValueOrDefault(preferences[SCAN], ScanStrategy.BALANCED),
             dualStack = preferences[DUAL_STACK] ?: true,
             validationEnabled = preferences[VALIDATION] ?: true,
@@ -62,6 +63,7 @@ class SettingsRepository(private val context: Context) {
             preferences[PROXY_PORT] = settings.proxyPort
             preferences[TRANSPORT] = settings.transport.name
             preferences[CARRIER] = settings.carrier.name
+            preferences[TOR_BRIDGE] = settings.torBridge.name
             preferences[SCAN] = settings.scanStrategy.name
             preferences[DUAL_STACK] = settings.dualStack
             preferences[VALIDATION] = settings.validationEnabled
@@ -103,6 +105,7 @@ class SettingsRepository(private val context: Context) {
         val PROXY_PORT = intPreferencesKey("proxy_port")
         val TRANSPORT = stringPreferencesKey("transport")
         val CARRIER = stringPreferencesKey("carrier")
+        val TOR_BRIDGE = stringPreferencesKey("tor_bridge")
         val SCAN = stringPreferencesKey("scan")
         val DUAL_STACK = booleanPreferencesKey("dual_stack")
         val VALIDATION = booleanPreferencesKey("validation")

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherTileService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherTileService.kt
@@ -81,6 +81,7 @@ class AetherTileService : TileService() {
                 settings.killSwitch,
                 settings.strictKillSwitch,
                 settings.carrier,
+                settings.torBridge,
             )
         }
     }

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
@@ -24,6 +24,7 @@ import com.whitedns.whiteaesther.core.PsiphonClient
 import com.whitedns.whiteaesther.core.TorClient
 import com.whitedns.whiteaesther.core.TorConfig
 import com.whitedns.whiteaesther.data.Carrier
+import com.whitedns.whiteaesther.data.TorBridge
 import com.whitedns.whiteaesther.data.ChainSettings
 import com.whitedns.whiteaesther.data.EngineMode
 import com.whitedns.whiteaesther.data.SplitTunnel
@@ -87,9 +88,18 @@ class AetherVpnService : VpnService() {
      * carrier that is not the engine never reaches the bridge at all.
      */
     private var carrier: Carrier = Carrier.AETHER
+
+    /**
+     * How Tor should reach its first hop this session.
+     *
+     * Held beside the carrier because it is part of how tor is started rather
+     * than something it can be told afterwards: the choice becomes lines in a
+     * torrc that tor reads once.
+     */
+    private var torBridge: TorBridge = TorBridge.NONE
     private val chain by lazy { ChainController(this) }
     private val psiphon by lazy { PsiphonClient(this) }
-    private val tor by lazy { TorClient(this) }
+    private var torClient: TorClient? = null
 
     /**
      * The carrier this session is using, or null when the engine is.
@@ -102,7 +112,9 @@ class AetherVpnService : VpnService() {
         get() = when (carrier) {
             Carrier.AETHER -> null
             Carrier.PSIPHON -> psiphon
-            Carrier.TOR -> tor
+            // Rebuilt when the bridge changes rather than held: the choice is
+            // part of how tor is started, not something it can be told later.
+            Carrier.TOR -> torClient
         }
 
     override fun onCreate() {
@@ -134,6 +146,9 @@ class AetherVpnService : VpnService() {
                 carrier = Carrier.entries
                     .firstOrNull { it.wireName == intent.getStringExtra(EXTRA_CARRIER) }
                     ?: Carrier.AETHER
+                torBridge = TorBridge.entries
+                    .firstOrNull { it.wireName == intent.getStringExtra(EXTRA_TOR_BRIDGE) }
+                    ?: TorBridge.NONE
                 // Held for the life of the session: giveUp runs long after
                 // this, and is not a place that can read DataStore.
                 blockOnFailure = intent.getBooleanExtra(EXTRA_KILL_SWITCH, false)
@@ -144,6 +159,7 @@ class AetherVpnService : VpnService() {
                         putString(LAST_CHAIN_CONFIG, chainSettings)
                         putString(LAST_SPLIT_CONFIG, splitSettings)
                         putString(LAST_CARRIER, carrier.wireName)
+                        putString(LAST_TOR_BRIDGE, torBridge.wireName)
                     }
                     restartPolicy = START_STICKY
                 } else {
@@ -152,6 +168,7 @@ class AetherVpnService : VpnService() {
                         remove(LAST_CHAIN_CONFIG)
                         remove(LAST_SPLIT_CONFIG)
                         remove(LAST_CARRIER)
+                        remove(LAST_TOR_BRIDGE)
                     }
                 }
                 startForegroundNow(sayNow(R.string.status_preparing_connection), sayNow(R.string.status_validating_engine))
@@ -165,6 +182,9 @@ class AetherVpnService : VpnService() {
                     carrier = Carrier.entries
                         .firstOrNull { it.wireName == preferences.getString(LAST_CARRIER, null) }
                         ?: Carrier.AETHER
+                    torBridge = TorBridge.entries
+                        .firstOrNull { it.wireName == preferences.getString(LAST_TOR_BRIDGE, null) }
+                        ?: TorBridge.NONE
                     restartPolicy = START_STICKY
                     startForegroundNow(sayNow(R.string.status_restoring), sayNow(R.string.status_reconnecting_tun))
                     replaceSession(
@@ -437,13 +457,13 @@ class AetherVpnService : VpnService() {
      * for the first would report the second broken for working normally.
      */
     private fun carrierWaitMs(): Long = when (carrier) {
-        Carrier.TOR -> TorConfig.BOOTSTRAP_TIMEOUT_MS
+        Carrier.TOR -> TorConfig.bootstrapTimeoutMs(torBridge)
         else -> PSIPHON_WAIT_MS
     }
 
     private fun stopCarrier() {
         runCatching { psiphon.stop() }
-        runCatching { tor.stop() }
+        runCatching { torClient?.stop() }
     }
 
     private suspend fun runCarrierSession(
@@ -510,10 +530,17 @@ class AetherVpnService : VpnService() {
         }
 
         EngineStatusStore.update(
-            EngineStatus(EngineStage.CONNECTING, mode, null, sayNow(R.string.status_carrier_connecting)),
+            EngineStatus(EngineStage.CONNECTING, mode, null, sayNow(R.string.status_carrier_connecting, sayNow(carrier.label))),
         )
-        updateNotification(mode, sayNow(R.string.status_carrier_connecting))
+        updateNotification(mode, sayNow(R.string.status_carrier_connecting, sayNow(carrier.label)))
 
+        if (carrier == Carrier.TOR) {
+            // Rebuilt rather than reused. The bridge is part of the torrc tor
+            // reads at startup, so a client built for the previous choice would
+            // start tor with the previous configuration and report success.
+            torClient?.let { runCatching { it.stop() } }
+            torClient = TorClient(this, torBridge)
+        }
         val client = carrierClient ?: run {
             reportError(mode, sayNow(R.string.err_carrier_failed))
             finishIfCurrent(sessionGeneration)
@@ -1413,6 +1440,8 @@ class AetherVpnService : VpnService() {
         private const val LAST_GOOD_TRANSPORT = "last_good_transport"
         private const val EXTRA_CARRIER = "carrier"
         private const val LAST_CARRIER = "last_carrier"
+        private const val EXTRA_TOR_BRIDGE = "torBridge"
+        private const val LAST_TOR_BRIDGE = "last_tor_bridge"
         // Psiphon establishes over a network that is actively hostile to it,
         // and its own timeout is two minutes. Ours has to be the longer of
         // the two or we would tear down a tunnel that was about to arrive.
@@ -1455,6 +1484,7 @@ class AetherVpnService : VpnService() {
             killSwitch: Boolean = false,
             strictKillSwitch: Boolean = false,
             carrier: Carrier = Carrier.AETHER,
+            torBridge: TorBridge = TorBridge.NONE,
         ) {
             ContextCompat.startForegroundService(
                 context,
@@ -1469,7 +1499,8 @@ class AetherVpnService : VpnService() {
                     // about the order of an enum that nothing enforces, and a
                     // carrier added in the middle of the list would silently
                     // reinterpret a pending intent written by the old build.
-                    .putExtra(EXTRA_CARRIER, carrier.wireName),
+                    .putExtra(EXTRA_CARRIER, carrier.wireName)
+                    .putExtra(EXTRA_TOR_BRIDGE, torBridge.wireName),
             )
         }
 

--- a/app/src/main/java/com/whitedns/whiteaesther/service/PluggableTransport.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/PluggableTransport.kt
@@ -1,0 +1,109 @@
+package com.whitedns.whiteaesther.service
+
+import android.util.Log
+import java.io.File
+
+/**
+ * A pluggable transport, launched by us rather than by tor.
+ *
+ * tor normally spawns these itself -- `ClientTransportPlugin obfs4 exec <path>`
+ * -- and speaks the managed-proxy protocol to whatever it started. Guardian
+ * Project's Android build cannot: `exec` aborts inside `pt_parse_transport_line`
+ * before tor has logged a word, which is the same as saying this libtor was
+ * built without the fork it needs. Measured, not assumed: the identical torrc
+ * with `socks5` in place of `exec` starts cleanly.
+ *
+ * So this does tor's half of that protocol. It sets the environment the spec
+ * defines, starts the binary, and reads back the `CMETHOD` lines saying which
+ * loopback port each transport ended up on -- which is exactly what the
+ * `socks5` form of the line then tells tor.
+ *
+ * See pt-spec.txt, "Pluggable Transport Specification (Version 1)".
+ */
+class PluggableTransport(
+    private val binary: File,
+    private val stateDir: File,
+) {
+    private var process: Process? = null
+
+    /**
+     * Starts [transports] and returns where each one is listening.
+     *
+     * @return transport name to `host:port`, empty if the proxy started but
+     *   offered none of what was asked for.
+     */
+    fun start(transports: List<String>): Map<String, String> {
+        check(process == null) { "already started" }
+        stateDir.mkdirs()
+
+        val builder = ProcessBuilder(binary.absolutePath)
+        builder.directory(stateDir)
+        // Errors on stdout with everything else, so one reader sees the whole
+        // conversation in the order it happened.
+        builder.redirectErrorStream(true)
+        builder.environment().apply {
+            put("TOR_PT_MANAGED_TRANSPORT_VER", "1")
+            put("TOR_PT_STATE_LOCATION", stateDir.absolutePath)
+            put("TOR_PT_CLIENT_TRANSPORTS", transports.joinToString(","))
+            // The proxy exits when its stdin closes, which is how it is stopped:
+            // a transport left running after tor has gone is a listener on
+            // loopback that nothing owns.
+            put("TOR_PT_EXIT_ON_STDIN_CLOSE", "1")
+        }
+
+        val started = builder.start()
+        process = started
+
+        val methods = mutableMapOf<String, String>()
+        val reader = started.inputStream.bufferedReader()
+        val deadline = System.currentTimeMillis() + HANDSHAKE_TIMEOUT_MS
+
+        // Read until the proxy says it is done, it says it cannot, or it has
+        // taken so long that it is not going to. Blocking is right here: there
+        // is nothing to do until it answers, and the answer arrives in
+        // milliseconds when it arrives at all.
+        while (System.currentTimeMillis() < deadline) {
+            val line = runCatching { reader.readLine() }.getOrNull() ?: break
+            Log.d("pt", line)
+            val parts = line.trim().split(' ')
+            when (parts.firstOrNull()) {
+                // CMETHOD <transport> <protocol> <address:port> [options]
+                "CMETHOD" -> if (parts.size >= 4) methods[parts[1]] = parts[3]
+                "CMETHODS" -> if (parts.getOrNull(1) == "DONE") return methods
+                // The proxy refusing one transport is not the proxy failing:
+                // the others may still be listening, so this is recorded and
+                // the loop continues to CMETHODS DONE.
+                "CMETHOD-ERROR" -> Log.w("pt", line)
+                "ENV-ERROR", "VERSION-ERROR" -> {
+                    stop()
+                    return emptyMap()
+                }
+            }
+        }
+        return methods
+    }
+
+    /**
+     * Stops the transport.
+     *
+     * Its stdin first, which is what the spec says to do and what lets it close
+     * its listeners on the way out; destroy afterwards for the case where it
+     * ignored that.
+     */
+    fun stop() {
+        val running = process ?: return
+        process = null
+        runCatching { running.outputStream.close() }
+        runCatching { running.waitFor() }
+        runCatching { running.destroy() }
+    }
+
+    private companion object {
+        /**
+         * Generous for what it is. The handshake is local and instant; a
+         * transport that has not answered in ten seconds has failed to start,
+         * and waiting longer only delays saying so.
+         */
+        const val HANDSHAKE_TIMEOUT_MS = 10_000L
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/service/TorCarrierService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/TorCarrierService.kt
@@ -16,6 +16,8 @@ import android.os.RemoteException
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.whitedns.whiteaesther.core.TorConfig
+import com.whitedns.whiteaesther.data.TorBridge
+import java.io.File
 import org.torproject.jni.TorService
 
 /**
@@ -47,6 +49,8 @@ class TorCarrierService : android.app.Service() {
     private var torService: TorService? = null
     private var torConnection: ServiceConnection? = null
     private var started = false
+    private var transport: PluggableTransport? = null
+    private var bootstrapWatcher: Thread? = null
 
     enum class State { STOPPED, CONNECTING, CONNECTED, FAILED }
 
@@ -70,12 +74,22 @@ class TorCarrierService : android.app.Service() {
                     // and it is not knowable before tor says it is listening.
                     socksPort = torService?.socksPort ?: 0
                     if (socksPort > 0) {
-                        state = State.CONNECTED
+                        // Listening, which is not the same as usable. This
+                        // status arrives when tor's control connection comes up,
+                        // and tor has a consensus to fetch and a circuit to
+                        // build after that. Reporting CONNECTED here is how a
+                        // slow transport ends up looking connected while it
+                        // carries nothing -- meek reached this point in seconds
+                        // and then failed to answer a single request in three
+                        // minutes. The port is published now so the chain can be
+                        // rendered; CONNECTED waits for the circuit.
+                        broadcast()
+                        awaitBootstrap()
                     } else {
                         state = State.FAILED
                         failure = "Tor started without a SOCKS listener"
+                        broadcast()
                     }
-                    broadcast()
                 }
 
                 TorService.STATUS_STARTING -> {
@@ -126,7 +140,11 @@ class TorCarrierService : android.app.Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            ACTION_START -> start(intent.getStringExtra(EXTRA_COUNTRY))
+            ACTION_START -> start(
+                TorBridge.entries.firstOrNull { it.wireName == intent.getStringExtra(EXTRA_BRIDGE) }
+                    ?: TorBridge.NONE,
+                intent.getStringExtra(EXTRA_COUNTRY),
+            )
             ACTION_STOP -> {
                 stopTor()
                 stopSelf()
@@ -142,7 +160,7 @@ class TorCarrierService : android.app.Service() {
         super.onDestroy()
     }
 
-    private fun start(exitCountry: String?) {
+    private fun start(bridge: TorBridge, exitCountry: String?) {
         if (started) return
         started = true
         state = State.CONNECTING
@@ -150,11 +168,40 @@ class TorCarrierService : android.app.Service() {
         socksPort = 0
         broadcast()
 
+        // The transport first, because the torrc has to name the port it
+        // ended up on. tor cannot start it for us -- see PluggableTransport --
+        // so a bridge mode whose proxy will not start has to fail here rather
+        // than become a tor that quietly connects directly.
+        var listening: String? = null
+        val wanted = TorConfig.transportName(bridge)
+        if (wanted != null) {
+            val binary = transportBinary(bridge)
+            if (binary == null) {
+                fail("This build ships no pluggable transports")
+                return
+            }
+            val proxy = PluggableTransport(binary, File(filesDir, "pt-state"))
+            val methods = runCatching { proxy.start(listOf(wanted)) }.getOrElse { error ->
+                fail("The $wanted transport did not start: ${error.message}")
+                return
+            }
+            listening = methods[wanted]
+            if (listening == null) {
+                runCatching { proxy.stop() }
+                fail("The $wanted transport started without offering $wanted")
+                return
+            }
+            transport = proxy
+            Log.i("tor", "$wanted is listening on $listening")
+        }
+
         runCatching {
             // Written before tor is started, because it is read once at
             // startup. TorService owns torrc-defaults -- that is where the
             // SOCKS port lands -- so this is the file for everything else.
-            TorService.getTorrc(this).writeText(TorConfig.render(exitCountry))
+            TorService.getTorrc(this).writeText(
+                TorConfig.render(bridge, exitCountry, listening),
+            )
         }.onFailure { error ->
             fail("Could not write tor's configuration: ${error.message}")
             return
@@ -170,8 +217,8 @@ class TorCarrierService : android.app.Service() {
                 val port = torService?.socksPort ?: 0
                 if (port > 0 && state != State.CONNECTED) {
                     socksPort = port
-                    state = State.CONNECTED
                     broadcast()
+                    awaitBootstrap()
                 }
             }
 
@@ -192,6 +239,67 @@ class TorCarrierService : android.app.Service() {
         }
     }
 
+    /**
+     * Where the transport executables were extracted, or null if this build
+     * ships none.
+     *
+     * They live in the app's native library directory because that is the only
+     * place Android will extract a file from an APK and leave it executable.
+     * Checked rather than assumed: a build made without native/tor/build.ps1
+     * has tor and no transports, and the bridge modes have to be unavailable
+     * rather than produce a torrc naming files that are not there.
+     */
+    private fun transportBinary(bridge: TorBridge): File? {
+        val dir = File(applicationInfo.nativeLibraryDir)
+        // Snowflake is its own program; obfs4 and meek_lite both come out of
+        // lyrebird. Named by which binary provides it rather than by the
+        // transport, because asking the wrong one for a transport it does not
+        // implement is a CMETHOD-ERROR and a bridge mode that never works.
+        val name = when (bridge) {
+            TorBridge.SNOWFLAKE -> "libsnowflake.so"
+            else -> "liblyrebird.so"
+        }
+        return File(dir, name).takeIf { it.exists() }
+    }
+
+    /**
+     * Waits for tor to finish bootstrapping, then reports CONNECTED.
+     *
+     * `status/bootstrap-phase` is tor's own account of how far it has got, and
+     * `PROGRESS=100` is the only point at which it can carry anything. Polled
+     * rather than subscribed because the control connection here is jtorctl's
+     * synchronous one and a poll a second for a minute costs nothing measurable.
+     *
+     * On its own thread: this is called from a broadcast receiver on the main
+     * looper, and tor can take minutes behind a bridge.
+     */
+    private fun awaitBootstrap() {
+        if (bootstrapWatcher?.isAlive == true) return
+        val watcher = Thread {
+            val deadline = System.currentTimeMillis() + BOOTSTRAP_TIMEOUT_MS
+            while (System.currentTimeMillis() < deadline && started) {
+                val phase = runCatching { torService?.getInfo("status/bootstrap-phase") }
+                    .getOrNull()
+                    .orEmpty()
+                if (phase.contains("PROGRESS=100") || phase.contains("TAG=done")) {
+                    state = State.CONNECTED
+                    Log.i("tor", "bootstrapped")
+                    broadcast()
+                    return@Thread
+                }
+                Thread.sleep(1_000)
+            }
+            if (started && state != State.CONNECTED) {
+                // Not a failure of ours to report as one: the session above has
+                // its own deadline and a better message for it. Left CONNECTING
+                // so that deadline is what decides.
+                Log.w("tor", "still bootstrapping after ${BOOTSTRAP_TIMEOUT_MS / 1000}s")
+            }
+        }
+        bootstrapWatcher = watcher
+        watcher.start()
+    }
+
     private fun stopTor() {
         if (!started) return
         started = false
@@ -199,6 +307,10 @@ class TorCarrierService : android.app.Service() {
         torConnection = null
         torService = null
         runCatching { stopService(Intent(this, TorService::class.java)) }
+        // After tor, not before. A transport killed while tor still holds a
+        // connection through it leaves tor retrying a port that has gone.
+        transport?.let { runCatching { it.stop() } }
+        transport = null
         socksPort = 0
         if (state != State.FAILED) state = State.STOPPED
         broadcast()
@@ -233,10 +345,20 @@ class TorCarrierService : android.app.Service() {
         const val ACTION_START = "com.whitedns.whiteaesther.TOR_START"
         const val ACTION_STOP = "com.whitedns.whiteaesther.TOR_STOP"
         const val EXTRA_COUNTRY = "country"
+        const val EXTRA_BRIDGE = "bridge"
         const val EXTRA_FAILURE = "failure"
 
         const val MSG_REGISTER = 1
         const val MSG_UNREGISTER = 2
         const val MSG_STATE = 3
+
+        /**
+         * How long the watcher keeps asking before it stops.
+         *
+         * Longer than any carrier deadline above it, deliberately: this thread
+         * giving up first would leave the session waiting on a report that is
+         * never coming, and the session has the better message for a timeout.
+         */
+        private const val BOOTSTRAP_TIMEOUT_MS = 420_000L
     }
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
@@ -63,6 +63,7 @@ import com.whitedns.whiteaesther.R
 import com.whitedns.whiteaesther.data.AppLanguage
 import com.whitedns.whiteaesther.data.AppSettings
 import com.whitedns.whiteaesther.data.Carrier
+import com.whitedns.whiteaesther.data.TorBridge
 import com.whitedns.whiteaesther.data.EndpointAddress
 import com.whitedns.whiteaesther.data.EndpointFamily
 import com.whitedns.whiteaesther.data.EndpointMode
@@ -723,6 +724,35 @@ fun RoutesScreen(
             // than a sentence saying so.
             if (!settings.carrier.usesEngine) {
                 Note(stringResource(R.string.carrier_not_engine_note))
+            }
+        }
+
+        // Only under Tor, because it is the only carrier that has this choice:
+        // Psiphon picks its own protocols and gives no say in it, and offering
+        // a control that belongs to one carrier under all of them is how a
+        // screen stops meaning anything.
+        if (settings.carrier == Carrier.TOR) {
+            Spacer(Modifier.height(12.dp))
+            AetherCard {
+                CardHead(
+                    stringResource(R.string.tor_bridge),
+                    stringResource(R.string.tor_bridge_subtitle),
+                )
+                Column(Modifier.padding(11.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    TorBridge.entries.forEach { bridge ->
+                        OptionRow(
+                            code = null,
+                            title = stringResource(bridge.label),
+                            subtitle = when (bridge) {
+                                TorBridge.NONE -> stringResource(R.string.tor_bridge_none_detail)
+                                TorBridge.OBFS4 -> stringResource(R.string.tor_bridge_obfs4_detail)
+                                TorBridge.SNOWFLAKE -> stringResource(R.string.tor_bridge_snowflake_detail)
+                            },
+                            selected = settings.torBridge == bridge,
+                            onClick = { onSettingsChange(settings.copy(torBridge = bridge)) },
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -460,7 +460,7 @@
     <string name="carrier_needs_chain_notice">این نسخه نمی‌تواند سایفون را اجرا کند: کتابخانهٔ مسیریابی موردنیازش موجود نیست.</string>
     <string name="carrier_whole_device_notice">سایفون فقط کل دستگاه را حمل می‌کند. پوشش را به «کل دستگاه» برگردانید یا اتر را انتخاب کنید.</string>
     <string name="status_starting_carrier">آماده‌سازی حامل…</string>
-    <string name="status_carrier_connecting">سایفون دنبال راه خروج می‌گردد. ممکن است یک دقیقه طول بکشد.</string>
+    <string name="status_carrier_connecting">%1$s دارد دنبال راه خروج می‌گردد. ممکن است یک دقیقه طول بکشد.</string>
     <string name="status_carrier_carries">متصل از طریق %1$s</string>
     <string name="err_carrier_whole_device_only">سایفون در حالت فقط-پراکسی اجرا نمی‌شود</string>
     <string name="err_carrier_needs_chain">این نسخه نمی‌تواند سایفون را مسیریابی کند: کتابخانهٔ زنجیره موجود نیست</string>
@@ -469,4 +469,13 @@
     <string name="carrier_not_engine_note">نقطهٔ پایانی، پروتکل و عمق جست‌وجوی پایین فقط برای اتر هستند. این حامل خودش راه خروجش را پیدا می‌کند.</string>
     <string name="carrier_tor">تور</string>
     <string name="carrier_tor_detail">سه رله، و خروجی نمی‌داند چه کسی درخواست کرده. کندترین گزینه، و UDP را حمل نمی‌کند.</string>
+    <string name="tor_bridge_none">مستقیم</string>
+    <string name="tor_bridge_obfs4">پل obfs4</string>
+    <string name="tor_bridge_snowflake">اسنوفلیک</string>
+    <string name="tor_bridge">تور چطور وصل شود</string>
+    <string name="tor_bridge_subtitle">مستقیم سریع‌ترین است و هرجا تور بسته باشد کار نمی‌کند</string>
+    <string name="tor_bridge_none_detail">مستقیم به شبکهٔ تور. سریع‌ترین، و اولین چیزی که فیلتر می‌شود.</string>
+    <string name="tor_bridge_obfs4_detail">شکل ترافیک را پنهان می‌کند. از پل‌های عمومی استفاده می‌کند که خودشان زودتر از همه بسته می‌شوند.</string>
+    <string name="tor_bridge_snowflake_detail">از طریق مرورگر داوطلبی که جواب بدهد. مقاوم است و سرعتش ثابت نیست.</string>
+    <string name="tor_bridge_missing">این نسخه ترنسپورتی همراه ندارد، پس فقط حالت مستقیم اجرا می‌شود.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -466,7 +466,7 @@
     <string name="carrier_needs_chain_notice">This build cannot run Psiphon: the routing library it needs is missing.</string>
     <string name="carrier_whole_device_notice">Psiphon carries the whole device only. Switch Coverage back to Whole device, or choose Aether.</string>
     <string name="status_starting_carrier">Preparing the carrier…</string>
-    <string name="status_carrier_connecting">Psiphon is looking for a way out. This can take a minute.</string>
+    <string name="status_carrier_connecting">%1$s is looking for a way out. This can take a minute.</string>
     <string name="status_carrier_carries">Connected through %1$s</string>
     <string name="err_carrier_whole_device_only">Psiphon cannot run in proxy-only mode</string>
     <string name="err_carrier_needs_chain">This build cannot route Psiphon: the chain library is missing</string>
@@ -475,4 +475,13 @@
     <string name="carrier_not_engine_note">Endpoint, protocol and discovery depth below apply to Aether only. This carrier finds its own way out.</string>
     <string name="carrier_tor">Tor</string>
     <string name="carrier_tor_detail">Three relays, and the exit does not know who asked. The slowest option, and it carries no UDP.</string>
+    <string name="tor_bridge_none">Direct</string>
+    <string name="tor_bridge_obfs4">obfs4 bridge</string>
+    <string name="tor_bridge_snowflake">Snowflake</string>
+    <string name="tor_bridge">How Tor connects</string>
+    <string name="tor_bridge_subtitle">Direct is fastest and blocked wherever Tor is</string>
+    <string name="tor_bridge_none_detail">Straight to the Tor network. Fastest, and the first thing a censor blocks.</string>
+    <string name="tor_bridge_obfs4_detail">Hides the shape of the traffic. Uses the public bridges, which are also the first ones blocked.</string>
+    <string name="tor_bridge_snowflake_detail">Through whichever volunteer browser answers. Survives a lot, and varies in speed.</string>
+    <string name="tor_bridge_missing">This build ships no pluggable transports, so only Direct can run.</string>
 </resources>

--- a/app/src/test/java/com/whitedns/whiteaesther/core/TorConfigTest.kt
+++ b/app/src/test/java/com/whitedns/whiteaesther/core/TorConfigTest.kt
@@ -1,0 +1,133 @@
+package com.whitedns.whiteaesther.core
+
+import com.whitedns.whiteaesther.data.TorBridge
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The `torrc` this app writes.
+ *
+ * Every check is against something that fails quietly. tor reads this file once
+ * at startup: a line naming a plugin binary that is not there stops it dead, a
+ * missing `UseBridges` leaves it connecting directly while the screen says
+ * otherwise, and `StrictNodes 1` turns a country preference into a tunnel that
+ * never builds.
+ */
+class TorConfigTest {
+    private val listening = "127.0.0.1:41234"
+
+    @Test
+    fun directNeedsNoBridgeAndSaysSoByOmission() {
+        val config = TorConfig.render(TorBridge.NONE, null, listening)
+
+        assertFalse(config.contains("UseBridges"))
+        assertFalse(config.contains("ClientTransportPlugin"))
+        assertFalse(config.contains("Bridge "))
+    }
+
+    @Test
+    fun obfs4NamesLyrebirdAndBringsBridgesWithIt() {
+        val config = TorConfig.render(TorBridge.OBFS4, null, listening)
+
+        assertTrue(config.contains("UseBridges 1"))
+        assertTrue(config.contains("ClientTransportPlugin obfs4 socks5 $listening"))
+        // A transport declared with no bridge to use it is tor connecting
+        // directly while the screen says it is behind a bridge.
+        assertTrue(config.lines().count { it.startsWith("Bridge obfs4 ") } >= 1)
+    }
+
+    @Test
+    fun snowflakeNamesItsOwnBinaryAndNotLyrebirds() {
+        val config = TorConfig.render(TorBridge.SNOWFLAKE, null, listening)
+
+        assertTrue(config.contains("ClientTransportPlugin snowflake socks5 $listening"))
+        assertTrue(config.contains("Bridge snowflake "))
+    }
+
+    @Test
+    fun everyBridgeModeNamesTheTransportItsProxyAnswersTo() {
+        // The name in the plugin line is the one the proxy announced in its
+        // CMETHOD, not the one on the screen: lyrebird calls meek meek_lite,
+        // and asking it for "meek" gets a CMETHOD-ERROR and a bridge mode that
+        // never works.
+        assertEquals("obfs4", TorConfig.transportName(TorBridge.OBFS4))
+        assertEquals("snowflake", TorConfig.transportName(TorBridge.SNOWFLAKE))
+        assertEquals(null, TorConfig.transportName(TorBridge.NONE))
+    }
+
+    @Test
+    fun withoutAnyTransportsNothingIsDeclaredAtAll() {
+        val config = TorConfig.render(TorBridge.OBFS4, null, null)
+
+        assertFalse(config.contains("ClientTransportPlugin"))
+        assertFalse(config.contains("UseBridges"))
+    }
+
+    @Test
+    fun anExitCountryIsAPreferenceAndNeverARequirement() {
+        val config = TorConfig.render(TorBridge.NONE, "NL", null)
+
+        assertTrue(config.contains("ExitNodes {nl}"))
+        // The whole reason this is here: several countries have a handful of
+        // exit relays and some have none, and strict enforcement on those is a
+        // tunnel that never builds.
+        assertTrue(config.contains("StrictNodes 0"))
+        assertFalse(config.contains("StrictNodes 1"))
+    }
+
+    @Test
+    fun nonsenseCountriesAreIgnoredRatherThanWritten() {
+        listOf("", "  ", "nether", "n").forEach { value ->
+            val config = TorConfig.render(TorBridge.NONE, value, null)
+            assertFalse("accepted '$value'", config.contains("ExitNodes"))
+        }
+    }
+
+    @Test
+    fun thisClientNeverServesAnything() {
+        val config = TorConfig.render(TorBridge.NONE, null, null)
+
+        // A resolver or a transparent port open on a phone is a service other
+        // apps on it can reach, and neither is used by anything here.
+        assertTrue(config.contains("DNSPort 0"))
+        assertTrue(config.contains("TransPort 0"))
+        assertTrue(config.contains("ClientOnly 1"))
+        assertTrue(config.contains("SocksPolicy reject *"))
+    }
+
+    @Test
+    fun everyBridgeModeHasLinesAndDirectHasNone() {
+        assertTrue(TorConfig.bridgeLines(TorBridge.NONE).isEmpty())
+        TorBridge.entries.filter { it != TorBridge.NONE }.forEach { bridge ->
+            assertTrue("$bridge has no bridge line", TorConfig.bridgeLines(bridge).isNotEmpty())
+            assertTrue(
+                "$bridge line does not name its transport",
+                TorConfig.bridgeLines(bridge).all { it.startsWith(bridge.wireName) },
+            )
+        }
+    }
+
+    @Test
+    fun aBridgeGetsLongerToBootstrapThanADirectConnection() {
+        // A bridge adds a hop that is itself being discovered, and a timeout set
+        // for a direct connection would report it broken for working normally.
+        assertTrue(
+            TorConfig.bootstrapTimeoutMs(TorBridge.OBFS4) >
+                TorConfig.bootstrapTimeoutMs(TorBridge.NONE),
+        )
+        TorBridge.entries.forEach { assertTrue(TorConfig.bootstrapTimeoutMs(it) > 0) }
+    }
+
+    @Test
+    fun bridgeWireNamesAreStable() {
+        // They cross a process boundary on an intent and outlive an upgrade in
+        // preferences.
+        assertEquals("none", TorBridge.NONE.wireName)
+        assertEquals("obfs4", TorBridge.OBFS4.wireName)
+        assertEquals("snowflake", TorBridge.SNOWFLAKE.wireName)
+        assertFalse(TorBridge.NONE.needsTransports)
+        assertTrue(TorBridge.entries.filter { it != TorBridge.NONE }.all { it.needsTransports })
+    }
+}

--- a/native/tor/README.md
+++ b/native/tor/README.md
@@ -39,26 +39,38 @@ Refused, a resolver falls back to TCP and a browser falls back off QUIC, both
 within a round trip. DNS still resolves because the chain's resolvers are
 DNS-over-HTTPS, which is TCP.
 
-## Pluggable transports are missing, and why
+## The transports, and why we start them
 
-Direct Tor only, for now. Where tor is blocked outright — which is the case this
-carrier is most wanted for — it will not connect.
+obfs4 and snowflake, both working. Built from source by `setup.ps1` and
+`build.ps1` as ordinary Go programs cross-compiled for Android, shipped as
+`liblyrebird.so` and `libsnowflake.so` -- executables named like libraries
+because that is the only form Android extracts and leaves executable, which is
+also why `jniLibs.useLegacyPackaging` being on is a prerequisite here rather
+than only a size decision.
 
-The obvious dependency is IPtProxy, which packages lyrebird (obfs4, meek,
-webtunnel) and snowflake. It cannot be used here: it is a gomobile library, so
-it ships `libgojni.so` and the `go.*` support classes, and so does Psiphon. Two
-of them in one APK is a duplicate-class failure at build time, and worse, one
-`libgojni.so` quietly winning over the other at packaging time — which would
-break whichever carrier lost, at run time, on a device.
+tor would normally launch them itself: `ClientTransportPlugin obfs4 exec <path>`.
+This build cannot. It aborts inside `pt_parse_transport_line` before logging a
+word, which is what a libtor built without the fork it needs looks like; the
+identical torrc with `socks5` in place of `exec` starts cleanly. Measured, not
+assumed.
 
-The way in is the way tor itself expects: transports as their own executables,
-launched with `ClientTransportPlugin`. lyrebird and snowflake are ordinary Go
-programs, and a Go program cross-compiled for Android with `-buildmode=pie` and
-shipped in `jniLibs` as `lib*.so` is extracted to `nativeLibraryDir` and can be
-executed from there. That extraction is why `useLegacyPackaging` being on is a
-prerequisite rather than only a size decision.
+So `PluggableTransport` does tor's half of the managed-proxy protocol -- sets the
+`TOR_PT_*` environment, starts the binary, reads the `CMETHOD` line naming the
+loopback port -- and the torrc hands tor that port. This is the same arrangement
+Orbot arrives at through IPtProxy, by a different road.
 
-That build is not written yet.
+meek is deliberately not offered. lyrebird starts it and tor accepts it, and then
+it never finishes bootstrapping: seven minutes on the public bridge, repeatedly,
+where obfs4 and snowflake took under a minute from the same network. The plumbing
+is generic, so it is a two-line change when there is a bridge worth pointing at.
+
+## Bootstrapped is not the same as listening
+
+`TorService` broadcasts `STATUS_ON` when tor's control connection comes up, which
+is before it has a consensus or a circuit. Reporting that as connected is how a
+slow transport ends up looking connected while carrying nothing -- which is
+exactly what meek did. `TorCarrierService` polls `status/bootstrap-phase` and
+only reports CONNECTED at `PROGRESS=100`.
 
 ## Licence
 

--- a/native/tor/build.ps1
+++ b/native/tor/build.ps1
@@ -1,0 +1,108 @@
+# Builds the pluggable transports as Android executables, one per ABI.
+#
+#   pwsh -File native/tor/build.ps1 [-Abi arm64-v8a,x86_64,armeabi-v7a]
+#
+# They are executables, not libraries, and they are named lib*.so anyway. That
+# is not a disguise: Android only extracts and marks executable the files under
+# lib/<abi>/ that end in .so, so a program that has to be exec'd has to be
+# called one. tor launches them itself through ClientTransportPlugin, which is
+# the interface they were written for.
+#
+# This is also why jniLibs.useLegacyPackaging must stay on. With it off, .so
+# files are mapped straight out of the APK and never land on the filesystem --
+# and a file that was never extracted cannot be executed.
+
+param([string[]]$Abi = @('arm64-v8a', 'x86_64', 'armeabi-v7a'))
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$out = Join-Path $here 'build'
+
+$Transports = @(
+    @{ Name = 'lyrebird';  Source = 'lyrebird';  Package = './cmd/lyrebird' },
+    @{ Name = 'snowflake'; Source = 'snowflake'; Package = './client' }
+)
+
+foreach ($transport in $Transports) {
+    $src = Join-Path $here "third_party/$($transport.Source)"
+    if (-not (Test-Path (Join-Path $src 'go.mod'))) {
+        throw "$($transport.Source) missing. Run native/tor/setup.ps1 first."
+    }
+}
+
+# Resolve the SDK the way Gradle does rather than assuming where it lives.
+$sdk = $env:ANDROID_HOME
+if (-not $sdk) { $sdk = $env:ANDROID_SDK_ROOT }
+if (-not $sdk) {
+    $props = Join-Path (Split-Path -Parent (Split-Path -Parent $here)) 'local.properties'
+    if (Test-Path $props) {
+        $match = Select-String -Path $props -Pattern 'sdk\.dir\s*=\s*(.+)' | Select-Object -First 1
+        if ($match) { $sdk = $match.Matches[0].Groups[1].Value.Trim().Replace('\:', ':') }
+    }
+}
+if (-not $sdk) { $sdk = Join-Path $env:LOCALAPPDATA 'Android\Sdk' }
+
+$ndkRoot = Join-Path $sdk 'ndk'
+if (-not (Test-Path $ndkRoot)) {
+    throw "Android NDK not found under $sdk. Set ANDROID_HOME, or sdk.dir in local.properties."
+}
+$ndk = (Get-ChildItem $ndkRoot -Directory | Sort-Object Name -Descending)[0].FullName
+
+$hostTag = if ($IsLinux) { 'linux-x86_64' } elseif ($IsMacOS) { 'darwin-x86_64' } else { 'windows-x86_64' }
+$bin = Join-Path $ndk "toolchains/llvm/prebuilt/$hostTag/bin"
+if (-not (Test-Path $bin)) { throw "NDK toolchain not found for this host: $bin" }
+$ext = if ($IsLinux -or $IsMacOS) { '' } else { '.cmd' }
+
+# minSdk is 26, so the toolchain is pinned there rather than to the NDK default.
+$targets = @{
+    'arm64-v8a'   = @{ Arch = 'arm64'; Clang = "aarch64-linux-android26-clang$ext";    Arm = $null }
+    'x86_64'      = @{ Arch = 'amd64'; Clang = "x86_64-linux-android26-clang$ext";     Arm = $null }
+    'armeabi-v7a' = @{ Arch = 'arm';   Clang = "armv7a-linux-androideabi26-clang$ext"; Arm = '7'  }
+}
+
+foreach ($name in $Abi) {
+    $spec = $targets[$name]
+    if (-not $spec) { throw "unknown ABI: $name" }
+    $cc = Join-Path $bin $spec.Clang
+    if (-not (Test-Path $cc)) { throw "NDK clang not found: $cc" }
+
+    $dir = Join-Path $out $name
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+
+    foreach ($transport in $Transports) {
+        $src = Join-Path $here "third_party/$($transport.Source)"
+        $so = Join-Path $dir "lib$($transport.Name).so"
+
+        Push-Location $src
+        try {
+            $env:GOFLAGS = '-mod=mod'
+            $env:CGO_ENABLED = '1'
+            $env:GOOS = 'android'
+            $env:GOARCH = $spec.Arch
+            $env:CC = $cc
+            if ($spec.Arm) { $env:GOARM = $spec.Arm } else { Remove-Item Env:GOARM -ErrorAction SilentlyContinue }
+
+            Write-Host "building $($transport.Name) for $name ..." -ForegroundColor Cyan
+            # -checklinkname=0 because both transports depend on wlynxg/anet,
+            # which reaches into net's internals by //go:linkname to enumerate
+            # interfaces on Android -- something the platform's own API will not
+            # do for an app. Go 1.23 started refusing those pulls by default.
+            # Relaxing it is upstream's own documented answer, not a workaround
+            # invented here.
+            #
+            # -buildmode=pie because Android will not exec a non-PIE binary, and
+            # has not since API 21.
+            go build -buildmode=pie -trimpath -ldflags="-w -s -checklinkname=0" -o $so $transport.Package
+            if ($LASTEXITCODE -ne 0) { throw "go build failed for $($transport.Name) on $name" }
+        } finally {
+            Pop-Location
+            Remove-Item Env:GOFLAGS, Env:CGO_ENABLED, Env:GOOS, Env:GOARCH, Env:CC, Env:GOARM -ErrorAction SilentlyContinue
+        }
+
+        $mb = [math]::Round((Get-Item $so).Length / 1MB, 1)
+        Write-Host "  -> $so  ($mb MB)" -ForegroundColor Green
+    }
+}
+
+Write-Host ""
+Write-Host "built: $($Abi -join ', ')" -ForegroundColor Green

--- a/native/tor/setup.ps1
+++ b/native/tor/setup.ps1
@@ -1,0 +1,63 @@
+# Fetches the pluggable transports tor launches, at pinned revisions.
+#
+#   pwsh -File native/tor/setup.ps1 [-Force]
+#
+# third_party/ is not committed: it is large, regenerable, and separately
+# licensed. tor itself is not fetched here at all -- it arrives as a maven
+# dependency from Guardian Project, who build it properly for every ABI.
+
+param([switch]$Force)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Pinned to a release tag rather than a branch, and for the same reason the
+# chain's sources are: a tag is an answer to "which source is this binary", and
+# these two reach the network on behalf of somebody trying not to be seen.
+$Transports = @(
+    @{
+        Name = 'lyrebird'
+        Repo = 'https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird.git'
+        Rev  = 'lyrebird-0.8.1'
+        # obfs4, meek_lite and webtunnel, all three from one binary.
+        Package = './cmd/lyrebird'
+    },
+    @{
+        Name = 'snowflake'
+        Repo = 'https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git'
+        Rev  = 'v2.14.1'
+        Package = './client'
+    }
+)
+
+$ThirdParty = Join-Path $here 'third_party'
+
+if ($Force -and (Test-Path $ThirdParty)) {
+    Write-Host "removing existing third_party/" -ForegroundColor Yellow
+    Remove-Item $ThirdParty -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $ThirdParty | Out-Null
+
+foreach ($transport in $Transports) {
+    $dir = Join-Path $ThirdParty $transport.Name
+    if (Test-Path (Join-Path $dir 'go.mod')) {
+        Push-Location $dir
+        $at = (git rev-parse --short HEAD)
+        Pop-Location
+        Write-Host "$($transport.Name) already present @ $at" -ForegroundColor Cyan
+        continue
+    }
+
+    Write-Host "fetching $($transport.Name) $($transport.Rev)..." -ForegroundColor Cyan
+    if (Test-Path $dir) { Remove-Item $dir -Recurse -Force }
+    # No --depth: a shallow clone cannot check out an arbitrary revision, and
+    # the pin is worth more than the download it saves.
+    git clone --quiet --filter=blob:none $transport.Repo $dir 2>&1 | Out-Null
+    Push-Location $dir
+    git checkout --quiet $transport.Rev 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { Pop-Location; throw "could not check out $($transport.Name) $($transport.Rev)" }
+    Pop-Location
+    Write-Host "  -> native/tor/third_party/$($transport.Name)" -ForegroundColor Green
+}
+
+Write-Host "`ntransports ready. Build with: pwsh -File native/tor/build.ps1" -ForegroundColor Green


### PR DESCRIPTION
## The transports

obfs4 and snowflake, built from source (`native/tor/setup.ps1`, `build.ps1`) as
ordinary Go programs cross-compiled for Android and shipped as `liblyrebird.so`
and `libsnowflake.so` — executables named like libraries because that is the only
form Android extracts and leaves executable. The packaging change in #25 was a
prerequisite for this, not only a size decision.

tor would normally launch them itself. **This build cannot:** `ClientTransportPlugin
... exec` aborts inside `pt_parse_transport_line` before tor logs a word, which is
what a libtor built without the fork it needs looks like. The identical torrc with
`socks5` starts cleanly. So `PluggableTransport` does tor's half of the managed-proxy
protocol — the `TOR_PT_*` environment, the process, the `CMETHOD` line naming the
port — and the torrc hands tor that port. Same arrangement Orbot reaches through
IPtProxy, by a different road.

**meek is not offered.** lyrebird starts it, tor accepts it, and it never finishes
bootstrapping — seven minutes on the public bridge, repeatedly, where obfs4 and
snowflake took under a minute from the same network.

## Bootstrapped is not listening

Found because of meek. `TorService` broadcasts `STATUS_ON` when tor's *control
connection* comes up — before it has a consensus or a circuit — so the session
reported CONNECTED while tor could carry nothing. Direct, obfs4 and snowflake hid
it by bootstrapping in seconds. `status/bootstrap-phase` is polled now and CONNECTED
waits for `PROGRESS=100`.

Also fixed: the connecting message said "Psiphon is looking for a way out" whatever
the carrier was.

## Verified

Every mode end to end on an API 36 emulator, exit address measured through tor's own
listener:

| mode | exit | phone |
| --- | --- | --- |
| direct | 45.84.107.200 | 119.76.15.180 |
| obfs4 | 45.148.10.111 | 119.76.15.180 |
| snowflake | 37.77.56.238 | 119.76.15.180 |

Psiphon's four live tests still pass. Unit tests and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)