### PR TITLE
Fetch Tor's bridges in one tap, and fix the stale built-in list

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ error. It is the first thing to read.
 | What you see | What it means |
 | --- | --- |
 | `... · retry 3 of 8 in 12s` | A path failed and it is trying another. Normal on a hostile network. |
+| `Could not reach Tor's bridge service` | Tap **Fetch bridges** while connected through Aether or Psiphon, or paste bridges from @GetBridgesBot. |
 | `... is looking for a way out` | A carrier is establishing. Psiphon tries many protocols at once; Tor fetches a consensus and builds a circuit. A minute is normal, and behind a bridge rather more. |
 | `Stopped after 8 attempts` | Nothing worked here. Try a different profile or network. |
 | `custom endpoint ... failed MASQUE validation` | The address you pinned is not reachable. Switch **Endpoint** back to Automatic. |

--- a/app/src/androidTest/java/com/whitedns/whiteaesther/service/TorSessionTest.kt
+++ b/app/src/androidTest/java/com/whitedns/whiteaesther/service/TorSessionTest.kt
@@ -2,6 +2,7 @@ package com.whitedns.whiteaesther.service
 
 import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
+import com.whitedns.whiteaesther.core.MoatClient
 import com.whitedns.whiteaesther.data.AddressReporter
 import com.whitedns.whiteaesther.data.AppSettings
 import com.whitedns.whiteaesther.data.Carrier
@@ -108,6 +109,57 @@ class TorSessionTest {
             "no log from mihomo reached the app",
             awaitLog("chain", timeoutMs = 20_000),
         )
+    }
+
+    @Test
+    fun bridgesCanBeFetchedFromTorAndThenCarryASession() {
+        assumeTrue("no tor argument, skipping the live carrier test", requested)
+
+        // What the one-click button does, end to end: ask Tor what it
+        // recommends here, take the first recommendation, and run tor behind
+        // it. The fetch is the half that is new; the rest is the same path a
+        // pasted bridge takes, which is the point of them sharing one field.
+        // Asked about a censored country rather than this machine's, which is
+        // the whole point of the feature: Tor answers an uncensored country with
+        // an empty list, correctly, and that would test nothing. In the app the
+        // country comes from the network the phone is actually on.
+        val country = InstrumentationRegistry.getArguments().getString("torCountry") ?: "ir"
+        val recommendations = runBlocking { MoatClient.recommendations(country) }
+            .getOrElse { error ->
+                throw AssertionError("could not reach Tor's bridge service: ${error.message}")
+            }
+        assertTrue("Tor recommended nothing for $country", recommendations.isNotEmpty())
+
+        val chosen = recommendations.first()
+        Log.i("carrier-diag", "tor recommends ${chosen.transport} for $country")
+
+        val settings = AppSettings(
+            mode = EngineMode.TUN,
+            carrier = Carrier.TOR,
+            torBridge = TorBridge.CUSTOM,
+            torBridges = chosen.lines.joinToString("\n"),
+        )
+        AetherVpnService.start(
+            context,
+            settings.toNativeJson(context),
+            settings.chainForService().encode(),
+            carrier = Carrier.TOR,
+            torBridge = TorBridge.CUSTOM,
+            torBridges = settings.torBridges,
+        )
+
+        val stage = awaitStage(EngineStage.CONNECTED, timeoutMs = 420_000)
+        assertEquals(
+            "fetched ${chosen.transport} bridges did not carry: " +
+                EngineStatusStore.status.value.message,
+            EngineStage.CONNECTED,
+            stage,
+        )
+
+        val port = EngineStatusStore.status.value.carrierSocksPort
+        val exit = runBlocking { AddressReporter.carrierAddress(port!!) }
+        assertTrue("nothing came back through tor", !exit.isNullOrBlank())
+        Log.i("carrier-diag", "tor(fetched ${chosen.transport}) exits at $exit")
     }
 
     private fun awaitLog(tag: String, timeoutMs: Long): Boolean {

--- a/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
@@ -265,6 +265,9 @@ class MainActivity : ComponentActivity() {
                     onScanEndpoints = viewModel::scanEndpoints,
                     onTestEndpoint = viewModel::testEndpoint,
                     onResetEndpoint = viewModel::resetEndpoint,
+                    onFetchBridges = { viewModel.fetchBridges(settings) },
+                    bridgesFetching = viewModel.bridgesFetching.collectAsStateWithLifecycle().value,
+                    bridgesMessage = viewModel.bridgesMessage.collectAsStateWithLifecycle().value,
                     onCancelEndpointScan = viewModel::cancelEndpointScan,
                     onRefreshChainNodes = { viewModel.refreshChainNodes(settings) },
                     onSelectChainNode = { node -> viewModel.selectChainNode(settings, node) },
@@ -428,6 +431,7 @@ class MainActivity : ComponentActivity() {
             settings.strictKillSwitch,
             settings.carrier,
             settings.torBridge,
+            settings.torBridges,
         )
     }
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
@@ -8,16 +8,21 @@ import androidx.lifecycle.viewModelScope
 import com.whitedns.whiteaesther.core.ChainController
 import com.whitedns.whiteaesther.core.ChainNode
 import com.whitedns.whiteaesther.core.EndpointScanResult
+import com.whitedns.whiteaesther.core.MoatClient
+import com.whitedns.whiteaesther.core.TorBridges
 import com.whitedns.whiteaesther.core.NativeAetherBridge
 import com.whitedns.whiteaesther.data.AddressReporter
 import com.whitedns.whiteaesther.data.AppSettings
 import com.whitedns.whiteaesther.data.EndpointMode
 import com.whitedns.whiteaesther.data.EngineMode
+import com.whitedns.whiteaesther.data.TorBridge
 import com.whitedns.whiteaesther.data.TunnelProtocol
 import com.whitedns.whiteaesther.data.SettingsRepository
 import com.whitedns.whiteaesther.data.UpdateChecker
 import com.whitedns.whiteaesther.service.AetherVpnService
+import com.whitedns.whiteaesther.service.EngineLog
 import com.whitedns.whiteaesther.service.EngineStage
+import com.whitedns.whiteaesther.service.LogLevel
 import com.whitedns.whiteaesther.service.EngineStatusStore
 import com.whitedns.whiteaesther.service.TrafficMeter
 import kotlinx.coroutines.Dispatchers
@@ -131,6 +136,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val endpointScannerState = mutableEndpointScannerState.asStateFlow()
     private var endpointJob: Job? = null
     private var realAddressJob: Job? = null
+    private var bridgeJob: Job? = null
+
+    /** Whether a bridge fetch is in flight, for the button that started it. */
+    private val mutableBridgesFetching = MutableStateFlow(false)
+    val bridgesFetching = mutableBridgesFetching.asStateFlow()
+
+    /** Why the last bridge fetch failed, or null. */
+    private val mutableBridgesMessage = MutableStateFlow<String?>(null)
+    val bridgesMessage = mutableBridgesMessage.asStateFlow()
 
     // Seeded with what the build can do, rather than waiting for a refresh
     // that only happens once connected. Whether the library is present is known
@@ -539,6 +553,66 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         AetherVpnService.forgetLastGoodTransport(getApplication())
         mutableEndpointScannerState.value = EndpointScannerState()
         scanEndpoints(cleared)
+    }
+
+    /**
+     * Asks Tor which bridges to use here, and saves them.
+     *
+     * Through the running carrier when there is one. That is the part Tor
+     * Browser cannot do and this app can: `bridges.torproject.org` is blocked
+     * in most of the places its answer is wanted, and this app already has two
+     * other ways out of exactly those places. Asked directly only when nothing
+     * is up, which is the case where direct is likely to work anyway.
+     *
+     * The country is the network's, not the exit's. Asked through a tunnel, the
+     * service would otherwise be told about Singapore and answer about
+     * Singapore, which is useless to somebody in Iran.
+     */
+    fun fetchBridges(settings: AppSettings) {
+        if (bridgeJob?.isActive == true) return
+        mutableBridgesMessage.value = null
+        mutableBridgesFetching.value = true
+        bridgeJob = viewModelScope.launch {
+            val context = getApplication<Application>()
+            val through = EngineStatusStore.status.value
+                .takeIf { it.stage == EngineStage.CONNECTED }
+                ?.carrierSocksPort
+            val country = MoatClient.country(context)
+            val result = MoatClient.recommendations(country, through)
+            mutableBridgesFetching.value = false
+
+            val recommendations = result.getOrElse { error ->
+                EngineLog.record(LogLevel.WARN, "bridges", error.message ?: "fetch failed")
+                mutableBridgesMessage.value = say(R.string.tor_bridges_failed)
+                return@launch
+            }
+            // The first one Tor lists, because it lists them in the order it
+            // recommends trying them for that country -- and the app can only
+            // run one transport at a time.
+            // Two different answers that a single failure message would blur.
+            // An empty list is Tor saying this network needs no help -- which is
+            // true of most of the world and is not a fault to report as one.
+            val best = recommendations.firstOrNull { it.lines.isNotEmpty() }
+            if (best == null) {
+                mutableBridgesMessage.value = say(R.string.tor_bridges_none_recommended, country.uppercase())
+                return@launch
+            }
+            EngineLog.record(
+                LogLevel.INFO,
+                "bridges",
+                "tor recommends ${best.transport} for $country: ${best.lines.size} bridges",
+            )
+            save(
+                settings.copy(
+                    torBridge = TorBridge.CUSTOM,
+                    torBridges = best.lines.joinToString("\n"),
+                ),
+            )
+        }
+    }
+
+    fun clearBridgesMessage() {
+        mutableBridgesMessage.value = null
     }
 
     fun scanEndpoints(settings: AppSettings) {

--- a/app/src/main/java/com/whitedns/whiteaesther/core/MoatClient.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/MoatClient.kt
@@ -1,0 +1,111 @@
+package com.whitedns.whiteaesther.core
+
+import android.content.Context
+import android.telephony.TelephonyManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URL
+import java.util.Locale
+
+/**
+ * Asks Tor which bridges to use here.
+ *
+ * This is the service Tor Browser's own "Connection Assist" uses. It takes a
+ * country and answers with the transports Tor currently recommends for it,
+ * newest first, each with real bridge lines -- and, unlike the built-in list,
+ * those lines come from BridgeDB, which hands out different ones to different
+ * people. That difference is the whole point: a bridge everybody has is a
+ * bridge everybody's censor has.
+ *
+ * No CAPTCHA. The per-user endpoint has one; this one does not, because what it
+ * returns is already rate-limited by being tied to a country rather than to a
+ * request.
+ */
+object MoatClient {
+    private const val ENDPOINT = "https://bridges.torproject.org/moat/circumvention/settings"
+    private const val TIMEOUT_MS = 30_000
+
+    /** One transport Tor recommends, with the bridges to use it with. */
+    data class Recommendation(val transport: String, val lines: List<String>)
+
+    /**
+     * The country to ask about.
+     *
+     * The network's, not the SIM's and not the phone's language. The SIM says
+     * where an account was opened and the language says what someone prefers to
+     * read; neither says which network is doing the filtering. Falls back to the
+     * locale only when there is no network operator to ask, which is roughly
+     * only on wifi-only hardware.
+     */
+    fun country(context: Context): String {
+        val telephony = context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+        val fromNetwork = telephony?.networkCountryIso?.takeIf { it.length == 2 }
+        return (fromNetwork ?: Locale.getDefault().country).lowercase(Locale.US)
+    }
+
+    /**
+     * @param socksPort a loopback SOCKS5 proxy to ask through, or null to ask
+     *   directly. This matters more than it looks: bridges.torproject.org is
+     *   blocked in most of the places its answer is needed, so the request goes
+     *   through whichever carrier is already carrying the device -- which is
+     *   something this app has and Tor Browser does not.
+     * @return what Tor recommends, in the order it recommends it, or a failure.
+     */
+    suspend fun recommendations(
+        country: String,
+        socksPort: Int? = null,
+    ): Result<List<Recommendation>> = withContext(Dispatchers.IO) {
+        runCatching {
+            val url = URL(ENDPOINT)
+            val connection = when (socksPort) {
+                null -> url.openConnection()
+                else -> url.openConnection(
+                    Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", socksPort)),
+                )
+            } as HttpURLConnection
+
+            connection.apply {
+                requestMethod = "POST"
+                connectTimeout = TIMEOUT_MS
+                readTimeout = TIMEOUT_MS
+                doOutput = true
+                setRequestProperty("Content-Type", "application/vnd.api+json")
+                // Nothing that identifies this client. The endpoint does not ask
+                // and there is no reason to volunteer.
+                setRequestProperty("User-Agent", "")
+            }
+
+            try {
+                connection.outputStream.use { it.write("""{"country":"$country"}""".toByteArray()) }
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                    error("Tor's bridge service answered ${connection.responseCode}")
+                }
+                val body = connection.inputStream.bufferedReader().use { it.readText() }
+                parse(body)
+            } finally {
+                connection.disconnect()
+            }
+        }
+    }
+
+    internal fun parse(body: String): List<Recommendation> {
+        val settings = JSONObject(body).optJSONArray("settings") ?: return emptyList()
+        return buildList {
+            for (index in 0 until settings.length()) {
+                val bridges = settings.optJSONObject(index)?.optJSONObject("bridges") ?: continue
+                val transport = bridges.optString("type").takeIf { it.isNotBlank() } ?: continue
+                val strings = bridges.optJSONArray("bridge_strings") ?: continue
+                val lines = buildList {
+                    for (line in 0 until strings.length()) {
+                        strings.optString(line).takeIf { it.isNotBlank() }?.let(::add)
+                    }
+                }
+                if (lines.isNotEmpty()) add(Recommendation(transport, lines))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/core/TorBridges.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/TorBridges.kt
@@ -1,0 +1,70 @@
+package com.whitedns.whiteaesther.core
+
+/**
+ * Bridge lines, whether the user pasted them or the app fetched them.
+ *
+ * One representation for both on purpose. A line from `@GetBridgesBot` and a
+ * line from Tor's own recommendation service are the same thing in the same
+ * format, and giving them two paths through the app would mean two ways for
+ * either to be wrong.
+ */
+object TorBridges {
+    /**
+     * Which binary provides a transport.
+     *
+     * lyrebird carries obfs4, meek_lite and webtunnel; snowflake is its own
+     * program. Asking the wrong one for a transport it does not implement is a
+     * `CMETHOD-ERROR` and a bridge mode that never works, so this is decided
+     * from the line rather than from what the screen was showing.
+     */
+    fun binaryFor(transport: String): String =
+        if (transport == "snowflake") "libsnowflake.so" else "liblyrebird.so"
+
+    /**
+     * The lines in [text] that are usable bridges.
+     *
+     * Forgiving about what surrounds them, because of where they come from: a
+     * user pastes a Telegram reply complete with its greeting, and a blank line
+     * or a stray word between bridges should not cost them the whole paste. A
+     * line that is not a bridge is dropped rather than refused.
+     */
+    fun parse(text: String): List<String> = text.lines()
+        .map { it.trim() }
+        .filter { line ->
+            if (line.isEmpty() || line.startsWith("#")) return@filter false
+            val parts = line.split(' ')
+            // <transport> <address:port> [fingerprint] [options]. The address is
+            // what separates a bridge line from a sentence about bridges.
+            parts.size >= 2 &&
+                parts[0].all { it.isLetterOrDigit() || it == '_' } &&
+                parts[1].contains(':')
+        }
+
+    /**
+     * Which transport a set of lines needs, or null if they name none.
+     *
+     * The first line decides, and lines naming a different transport are
+     * dropped by [forTransport]. Mixing them would mean starting two proxies
+     * and telling tor about one, which fails as a bridge it cannot reach rather
+     * than as the configuration error it is.
+     */
+    fun transportOf(lines: List<String>): String? =
+        lines.firstOrNull()?.split(' ')?.firstOrNull()?.takeIf { it.isNotBlank() }
+
+    /** Only the lines belonging to [transport]. */
+    fun forTransport(lines: List<String>, transport: String): List<String> =
+        lines.filter { it.startsWith("$transport ") }
+
+    /**
+     * A short description of what a paste amounts to, for the screen.
+     *
+     * The count matters as much as the type: one bridge is a single point of
+     * failure and the user is the only one who can do anything about that.
+     */
+    fun summarise(text: String): String? {
+        val lines = parse(text)
+        val transport = transportOf(lines) ?: return null
+        val count = forTransport(lines, transport).size
+        return "$count $transport"
+    }
+}

--- a/app/src/main/java/com/whitedns/whiteaesther/core/TorClient.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/TorClient.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 class TorClient(
     private val context: Context,
     private val bridge: TorBridge,
+    private val customBridges: String,
 ) : CarrierClient {
     private val mutableState = MutableStateFlow(CarrierSnapshot())
     override val state = mutableState
@@ -63,7 +64,8 @@ class TorClient(
         context.startService(
             Intent(context, TorCarrierService::class.java)
                 .setAction(TorCarrierService.ACTION_START)
-                .putExtra(TorCarrierService.EXTRA_BRIDGE, bridge.wireName),
+                .putExtra(TorCarrierService.EXTRA_BRIDGE, bridge.wireName)
+                .putExtra(TorCarrierService.EXTRA_BRIDGES, customBridges),
         )
 
         val settled = withTimeoutOrNull(timeoutMs) {

--- a/app/src/main/java/com/whitedns/whiteaesther/core/TorConfig.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/core/TorConfig.kt
@@ -14,43 +14,44 @@ object TorConfig {
     /**
      * The bridges tor falls back on when the user has not been given any.
      *
-     * These are the lines Tor Browser ships, unchanged. They are public by
-     * design -- a bridge nobody can find is a bridge nobody can use -- and by
-     * the same token they are the first ones a censor blocks. A bridge from
-     * bridges.torproject.org beats every one of them, which is why the screen
-     * says so, but a default that sometimes works beats a field the user has to
-     * fill in before anything happens at all.
+     * Tor's own built-in list, taken from its service and checked reachable --
+     * `native/tor/refresh-bridges.ps1` does both and is the way to redo it. The
+     * first version of this list was written from memory and two of its three
+     * addresses had been gone long enough to be unreachable from an uncensored
+     * network, which is a failure worth not repeating: a list of addresses
+     * rots, and there has to be a way to tell that it has.
      *
-     * Not fetched at runtime. Asking a server which bridges to use is a request
-     * that names this device to somebody, from an app whose whole purpose is
-     * not to make those.
+     * They are public by design -- a bridge nobody can find is a bridge nobody
+     * can use -- and by the same token they are the first ones a censor blocks,
+     * and in the places this mode matters most they are already blocked.
+     * [TorBridge.CUSTOM] is the answer there. These are the fallback for
+     * everywhere else.
      */
     private val DEFAULT_OBFS4 = listOf(
-        "obfs4 192.95.36.142:443 CDF2E852BF539B82BD10E27E9115A31734E378C2 " +
-            "cert=qUVQ0srL1JI/vO6V6m/24anYXiJD3QP2HgzUKQtQ7GRqqUvs7P+tG43RtAqdhLOALP7DJQ " +
-            "iat-mode=1",
-        "obfs4 37.218.245.14:38224 D9A82D2F9C2F65A18407B1D2B764F130847F8B5D " +
-            "cert=bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg " +
-            "iat-mode=0",
-        "obfs4 85.31.186.98:443 011F2599C0E9B27EE74B353155E244813763C3E5 " +
-            "cert=ayq0XzCwhpdysn5o0EyDUbmSOx3X/oTEbzDMvczHOdBJKlvIdHHLJGkZARtT4dcBFArPPg " +
-            "iat-mode=0",
+        "obfs4 37.218.245.14:38224 D9A82D2F9C2F65A18407B1D2B764F130847F8B5D cert=bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg iat-mode=0",
+        "obfs4 212.83.43.95:443 BFE712113A72899AD685764B211FACD30FF52C31 cert=ayq0XzCwhpdysn5o0EyDUbmSOx3X/oTEbzDMvczHOdBJKlvIdHHLJGkZARtT4dcBFArPPg iat-mode=1",
+        "obfs4 51.222.13.177:80 5EDAC3B810E12B01F6FD8050D2FD3E277B289A08 cert=2uplIpLQ0q9+0qMFrK5pkaYRDOe460LL9WHBvatgkuRr/SL31wBOEupaMMJ6koRE6Ld0ew iat-mode=0",
+        "obfs4 45.145.95.6:27015 C5B7CD6946FF10C5B3E89691A7D3F2C122D2117C cert=TD7PbUO0/0k6xYHMPW3vJxICfkMZNdkRrb63Zhl5j9dW3iRGiCx0A7mPhe5T2EDzQ35+Zw iat-mode=0",
+        "obfs4 209.148.46.65:443 74FAD13168806246602538555B5521A0383A1875 cert=ssH+9rP8dG2NLDN2XuFw63hIO/9MNNinLmxQDpVa+7kTOa9/m+tGWT1SmSYpQ9uTBGa6Hw iat-mode=0",
+        "obfs4 212.83.43.74:443 39562501228A4D5E27FCA4C0C81A01EE23AE3EE4 cert=PBwr+S8JTVZo6MPdHnkTwXJPILWADLqfMGoVvhZClMq/Urndyd42BwX9YFJHZnBB3H0XCw iat-mode=1",
     )
 
     /** One line, and it is the same one every snowflake client uses. */
     private const val DEFAULT_SNOWFLAKE =
-        "snowflake 192.0.2.3:80 2B280B23E1107BB62ABFC40DDCC8824814F80A72 " +
-            "fingerprint=2B280B23E1107BB62ABFC40DDCC8824814F80A72 " +
-            "url=https://1098762253.rsc.cdn77.org/ " +
-            "fronts=www.cdn77.com,www.phpmyadmin.net " +
-            "ice=stun:stun.l.google.com:19302,stun:stun.antisip.com:3478 " +
-            "utls-imitate=hellorandomizedalpn"
+        "snowflake 192.0.2.3:80 2B280B23E1107BB62ABFC40DDCC8824814F80A72 fingerprint=2B280B23E1107BB62ABFC40DDCC8824814F80A72 url=https://1098762253.rsc.cdn77.org/ fronts=app.datapacket.com,www.datapacket.com ice=stun:stun.epygi.com:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.mixvoip.com:3478,stun:stun.telnyx.com:3478,stun:stun.hot-chilli.net:3478,stun:stun.fitauto.ru:3478,stun:stun.m-online.net:3478 utls-imitate=hellorandomizedalpn"
 
-    /** The transport a bridge mode needs, by the name the proxy answers to. */
-    fun transportName(bridge: TorBridge): String? = when (bridge) {
+    /**
+     * The transport a bridge mode needs, by the name the proxy answers to.
+     *
+     * For custom bridges it comes from the lines themselves, because that is
+     * the only thing that knows: a paste can be obfs4, snowflake or webtunnel
+     * and the screen cannot tell which until it is read.
+     */
+    fun transportName(bridge: TorBridge, custom: String = ""): String? = when (bridge) {
         TorBridge.NONE -> null
         TorBridge.OBFS4 -> "obfs4"
         TorBridge.SNOWFLAKE -> "snowflake"
+        TorBridge.CUSTOM -> TorBridges.transportOf(TorBridges.parse(custom))
     }
 
     /**
@@ -69,6 +70,7 @@ object TorConfig {
         bridge: TorBridge,
         exitCountry: String?,
         transport: String?,
+        customBridges: String = "",
     ): String = buildString {
         // Nothing is served, dialled or published by this client.
         appendLine("SocksPolicy accept 127.0.0.1/8")
@@ -82,11 +84,15 @@ object TorConfig {
         appendLine("DNSPort 0")
         appendLine("TransPort 0")
 
-        val name = transportName(bridge)
-        if (name != null && transport != null) {
+        val name = transportName(bridge, customBridges)
+        val bridges = bridgeLines(bridge, customBridges)
+        // Both, or neither. A transport with no bridge to use it is tor
+        // connecting directly while the screen says it is behind a bridge, and
+        // bridges with no transport is tor refusing to start.
+        if (name != null && transport != null && bridges.isNotEmpty()) {
             appendLine("ClientTransportPlugin $name socks5 $transport")
             appendLine("UseBridges 1")
-            bridgeLines(bridge).forEach { appendLine("Bridge $it") }
+            bridges.forEach { appendLine("Bridge $it") }
         }
 
         val country = exitCountry?.trim()?.lowercase()?.takeIf { it.length == 2 }
@@ -100,11 +106,22 @@ object TorConfig {
         }
     }
 
-    internal fun bridgeLines(bridge: TorBridge): List<String> = when (bridge) {
-        TorBridge.NONE -> emptyList()
-        TorBridge.OBFS4 -> DEFAULT_OBFS4
-        TorBridge.SNOWFLAKE -> listOf(DEFAULT_SNOWFLAKE)
-    }
+    internal fun bridgeLines(bridge: TorBridge, custom: String = ""): List<String> =
+        when (bridge) {
+            TorBridge.NONE -> emptyList()
+            TorBridge.OBFS4 -> DEFAULT_OBFS4
+            TorBridge.SNOWFLAKE -> listOf(DEFAULT_SNOWFLAKE)
+            TorBridge.CUSTOM -> {
+                val lines = TorBridges.parse(custom)
+                // Only the ones matching the transport we are about to start.
+                // A paste holding two kinds would otherwise start one proxy and
+                // hand tor bridges for the other, which fails as an unreachable
+                // bridge rather than as the mix-up it is.
+                TorBridges.transportOf(lines)
+                    ?.let { TorBridges.forTransport(lines, it) }
+                    ?: emptyList()
+            }
+        }
 
     /**
      * How long to wait for a circuit before calling it a failure.
@@ -118,4 +135,14 @@ object TorConfig {
         TorBridge.NONE -> 240_000L
         else -> 300_000L
     }
+
+    /** Why a bridge mode cannot start, or null when it can. */
+    fun refusal(bridge: TorBridge, customBridges: String): Refusal? = when {
+        bridge != TorBridge.CUSTOM -> null
+        TorBridges.parse(customBridges).isEmpty() -> Refusal.NO_BRIDGES
+        transportName(bridge, customBridges) == null -> Refusal.NO_BRIDGES
+        else -> null
+    }
+
+    enum class Refusal { NO_BRIDGES }
 }

--- a/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/AppSettings.kt
@@ -148,6 +148,16 @@ enum class TorBridge(val wireName: String, @StringRes val label: Int) {
     NONE("none", R.string.tor_bridge_none),
     OBFS4("obfs4", R.string.tor_bridge_obfs4),
     SNOWFLAKE("snowflake", R.string.tor_bridge_snowflake),
+
+    /**
+     * Bridges the user was given, or the app fetched for them.
+     *
+     * The only mode with a real chance where Tor is properly blocked. The two
+     * above use the bridges Tor publishes for everyone, and a bridge everybody
+     * has is a bridge everybody's censor has -- they are the first addresses to
+     * go and they are already gone in the places this mode exists for.
+     */
+    CUSTOM("custom", R.string.tor_bridge_custom),
     // meek is deliberately absent. lyrebird starts it and tor accepts it, and
     // then it never finishes bootstrapping -- seven minutes on the public
     // bridge, repeatedly, while obfs4 and snowflake took under a minute from
@@ -269,6 +279,14 @@ data class AppSettings(
      * blocked in the places a bridge is required.
      */
     val torBridge: TorBridge = TorBridge.NONE,
+    /**
+     * Bridge lines for [TorBridge.CUSTOM], one per line.
+     *
+     * Kept as text rather than parsed, because it is text the user pasted and
+     * they should get it back exactly as they left it. Everything that needs
+     * structure asks [com.whitedns.whiteaesther.core.TorBridges] for it.
+     */
+    val torBridges: String = "",
     // Automatic, because the answer depends on the network and the user has no
     // way to know it. A fixed default of H3 meant every install on a network
     // that blocks UDP spent minutes failing before anything else was tried.

--- a/app/src/main/java/com/whitedns/whiteaesther/data/SettingsRepository.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/data/SettingsRepository.kt
@@ -20,6 +20,7 @@ class SettingsRepository(private val context: Context) {
             transport = enumValueOrDefault(preferences[TRANSPORT], TunnelProtocol.AUTO),
             carrier = enumValueOrDefault(preferences[CARRIER], Carrier.AETHER),
             torBridge = enumValueOrDefault(preferences[TOR_BRIDGE], TorBridge.NONE),
+            torBridges = preferences[TOR_BRIDGES].orEmpty(),
             scanStrategy = enumValueOrDefault(preferences[SCAN], ScanStrategy.BALANCED),
             dualStack = preferences[DUAL_STACK] ?: true,
             validationEnabled = preferences[VALIDATION] ?: true,
@@ -64,6 +65,7 @@ class SettingsRepository(private val context: Context) {
             preferences[TRANSPORT] = settings.transport.name
             preferences[CARRIER] = settings.carrier.name
             preferences[TOR_BRIDGE] = settings.torBridge.name
+            preferences[TOR_BRIDGES] = settings.torBridges
             preferences[SCAN] = settings.scanStrategy.name
             preferences[DUAL_STACK] = settings.dualStack
             preferences[VALIDATION] = settings.validationEnabled
@@ -106,6 +108,7 @@ class SettingsRepository(private val context: Context) {
         val TRANSPORT = stringPreferencesKey("transport")
         val CARRIER = stringPreferencesKey("carrier")
         val TOR_BRIDGE = stringPreferencesKey("tor_bridge")
+        val TOR_BRIDGES = stringPreferencesKey("tor_bridges")
         val SCAN = stringPreferencesKey("scan")
         val DUAL_STACK = booleanPreferencesKey("dual_stack")
         val VALIDATION = booleanPreferencesKey("validation")

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherTileService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherTileService.kt
@@ -82,6 +82,7 @@ class AetherTileService : TileService() {
                 settings.strictKillSwitch,
                 settings.carrier,
                 settings.torBridge,
+                settings.torBridges,
             )
         }
     }

--- a/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/AetherVpnService.kt
@@ -97,6 +97,7 @@ class AetherVpnService : VpnService() {
      * torrc that tor reads once.
      */
     private var torBridge: TorBridge = TorBridge.NONE
+    private var torBridges: String = ""
     private val chain by lazy { ChainController(this) }
     private val psiphon by lazy { PsiphonClient(this) }
     private var torClient: TorClient? = null
@@ -149,6 +150,7 @@ class AetherVpnService : VpnService() {
                 torBridge = TorBridge.entries
                     .firstOrNull { it.wireName == intent.getStringExtra(EXTRA_TOR_BRIDGE) }
                     ?: TorBridge.NONE
+                torBridges = intent.getStringExtra(EXTRA_TOR_BRIDGES).orEmpty()
                 // Held for the life of the session: giveUp runs long after
                 // this, and is not a place that can read DataStore.
                 blockOnFailure = intent.getBooleanExtra(EXTRA_KILL_SWITCH, false)
@@ -160,6 +162,7 @@ class AetherVpnService : VpnService() {
                         putString(LAST_SPLIT_CONFIG, splitSettings)
                         putString(LAST_CARRIER, carrier.wireName)
                         putString(LAST_TOR_BRIDGE, torBridge.wireName)
+                        putString(LAST_TOR_BRIDGES, torBridges)
                     }
                     restartPolicy = START_STICKY
                 } else {
@@ -169,6 +172,7 @@ class AetherVpnService : VpnService() {
                         remove(LAST_SPLIT_CONFIG)
                         remove(LAST_CARRIER)
                         remove(LAST_TOR_BRIDGE)
+                        remove(LAST_TOR_BRIDGES)
                     }
                 }
                 startForegroundNow(sayNow(R.string.status_preparing_connection), sayNow(R.string.status_validating_engine))
@@ -185,6 +189,7 @@ class AetherVpnService : VpnService() {
                     torBridge = TorBridge.entries
                         .firstOrNull { it.wireName == preferences.getString(LAST_TOR_BRIDGE, null) }
                         ?: TorBridge.NONE
+                    torBridges = preferences.getString(LAST_TOR_BRIDGES, null).orEmpty()
                     restartPolicy = START_STICKY
                     startForegroundNow(sayNow(R.string.status_restoring), sayNow(R.string.status_reconnecting_tun))
                     replaceSession(
@@ -539,7 +544,7 @@ class AetherVpnService : VpnService() {
             // reads at startup, so a client built for the previous choice would
             // start tor with the previous configuration and report success.
             torClient?.let { runCatching { it.stop() } }
-            torClient = TorClient(this, torBridge)
+            torClient = TorClient(this, torBridge, torBridges)
         }
         val client = carrierClient ?: run {
             reportError(mode, sayNow(R.string.err_carrier_failed))
@@ -1441,6 +1446,8 @@ class AetherVpnService : VpnService() {
         private const val EXTRA_CARRIER = "carrier"
         private const val LAST_CARRIER = "last_carrier"
         private const val EXTRA_TOR_BRIDGE = "torBridge"
+        private const val EXTRA_TOR_BRIDGES = "torBridges"
+        private const val LAST_TOR_BRIDGES = "last_tor_bridges"
         private const val LAST_TOR_BRIDGE = "last_tor_bridge"
         // Psiphon establishes over a network that is actively hostile to it,
         // and its own timeout is two minutes. Ours has to be the longer of
@@ -1485,6 +1492,7 @@ class AetherVpnService : VpnService() {
             strictKillSwitch: Boolean = false,
             carrier: Carrier = Carrier.AETHER,
             torBridge: TorBridge = TorBridge.NONE,
+            torBridges: String = "",
         ) {
             ContextCompat.startForegroundService(
                 context,
@@ -1500,7 +1508,8 @@ class AetherVpnService : VpnService() {
                     // carrier added in the middle of the list would silently
                     // reinterpret a pending intent written by the old build.
                     .putExtra(EXTRA_CARRIER, carrier.wireName)
-                    .putExtra(EXTRA_TOR_BRIDGE, torBridge.wireName),
+                    .putExtra(EXTRA_TOR_BRIDGE, torBridge.wireName)
+                    .putExtra(EXTRA_TOR_BRIDGES, torBridges),
             )
         }
 

--- a/app/src/main/java/com/whitedns/whiteaesther/service/TorCarrierService.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/service/TorCarrierService.kt
@@ -15,6 +15,7 @@ import android.os.Messenger
 import android.os.RemoteException
 import android.util.Log
 import androidx.core.content.ContextCompat
+import com.whitedns.whiteaesther.core.TorBridges
 import com.whitedns.whiteaesther.core.TorConfig
 import com.whitedns.whiteaesther.data.TorBridge
 import java.io.File
@@ -144,6 +145,7 @@ class TorCarrierService : android.app.Service() {
                 TorBridge.entries.firstOrNull { it.wireName == intent.getStringExtra(EXTRA_BRIDGE) }
                     ?: TorBridge.NONE,
                 intent.getStringExtra(EXTRA_COUNTRY),
+                intent.getStringExtra(EXTRA_BRIDGES).orEmpty(),
             )
             ACTION_STOP -> {
                 stopTor()
@@ -160,7 +162,7 @@ class TorCarrierService : android.app.Service() {
         super.onDestroy()
     }
 
-    private fun start(bridge: TorBridge, exitCountry: String?) {
+    private fun start(bridge: TorBridge, exitCountry: String?, customBridges: String) {
         if (started) return
         started = true
         state = State.CONNECTING
@@ -173,9 +175,13 @@ class TorCarrierService : android.app.Service() {
         // so a bridge mode whose proxy will not start has to fail here rather
         // than become a tor that quietly connects directly.
         var listening: String? = null
-        val wanted = TorConfig.transportName(bridge)
+        TorConfig.refusal(bridge, customBridges)?.let {
+            fail("No usable bridge lines. Paste the ones you were given, or fetch them.")
+            return
+        }
+        val wanted = TorConfig.transportName(bridge, customBridges)
         if (wanted != null) {
-            val binary = transportBinary(bridge)
+            val binary = transportBinary(wanted)
             if (binary == null) {
                 fail("This build ships no pluggable transports")
                 return
@@ -200,7 +206,7 @@ class TorCarrierService : android.app.Service() {
             // startup. TorService owns torrc-defaults -- that is where the
             // SOCKS port lands -- so this is the file for everything else.
             TorService.getTorrc(this).writeText(
-                TorConfig.render(bridge, exitCountry, listening),
+                TorConfig.render(bridge, exitCountry, listening, customBridges),
             )
         }.onFailure { error ->
             fail("Could not write tor's configuration: ${error.message}")
@@ -249,17 +255,9 @@ class TorCarrierService : android.app.Service() {
      * has tor and no transports, and the bridge modes have to be unavailable
      * rather than produce a torrc naming files that are not there.
      */
-    private fun transportBinary(bridge: TorBridge): File? {
+    private fun transportBinary(transport: String): File? {
         val dir = File(applicationInfo.nativeLibraryDir)
-        // Snowflake is its own program; obfs4 and meek_lite both come out of
-        // lyrebird. Named by which binary provides it rather than by the
-        // transport, because asking the wrong one for a transport it does not
-        // implement is a CMETHOD-ERROR and a bridge mode that never works.
-        val name = when (bridge) {
-            TorBridge.SNOWFLAKE -> "libsnowflake.so"
-            else -> "liblyrebird.so"
-        }
-        return File(dir, name).takeIf { it.exists() }
+        return File(dir, TorBridges.binaryFor(transport)).takeIf { it.exists() }
     }
 
     /**
@@ -346,6 +344,7 @@ class TorCarrierService : android.app.Service() {
         const val ACTION_STOP = "com.whitedns.whiteaesther.TOR_STOP"
         const val EXTRA_COUNTRY = "country"
         const val EXTRA_BRIDGE = "bridge"
+        const val EXTRA_BRIDGES = "bridges"
         const val EXTRA_FAILURE = "failure"
 
         const val MSG_REGISTER = 1

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
@@ -63,6 +63,7 @@ import com.whitedns.whiteaesther.R
 import com.whitedns.whiteaesther.data.AppLanguage
 import com.whitedns.whiteaesther.data.AppSettings
 import com.whitedns.whiteaesther.data.Carrier
+import com.whitedns.whiteaesther.core.TorBridges
 import com.whitedns.whiteaesther.data.TorBridge
 import com.whitedns.whiteaesther.data.EndpointAddress
 import com.whitedns.whiteaesther.data.EndpointFamily
@@ -644,12 +645,19 @@ fun RoutesScreen(
     onGoToEndpoint: () -> Unit,
     onGoToChain: () -> Unit = {},
     onGoToRoutingRules: () -> Unit = {},
+    onFetchBridges: () -> Unit = {},
+    bridgesFetching: Boolean = false,
+    bridgesMessage: String? = null,
     endpointModifier: Modifier = Modifier,
     chainModifier: Modifier = Modifier,
     routingRulesModifier: Modifier = Modifier,
 ) {
     var advanced by rememberSaveable(settings.showAdvanced) { mutableStateOf(settings.showAdvanced) }
     val active = settings.activeProfile()
+    // Held locally so typing is not fought by the settings flow round-tripping
+    // through DataStore, and refreshed when something else writes them -- which
+    // is what the fetch button does.
+    var bridgeText by rememberSaveable(settings.torBridges) { mutableStateOf(settings.torBridges) }
 
     ScreenColumn {
         CrumbBar(stringResource(R.string.routes))
@@ -747,10 +755,71 @@ fun RoutesScreen(
                                 TorBridge.NONE -> stringResource(R.string.tor_bridge_none_detail)
                                 TorBridge.OBFS4 -> stringResource(R.string.tor_bridge_obfs4_detail)
                                 TorBridge.SNOWFLAKE -> stringResource(R.string.tor_bridge_snowflake_detail)
+                                TorBridge.CUSTOM -> stringResource(R.string.tor_bridge_custom_detail)
                             },
                             selected = settings.torBridge == bridge,
                             onClick = { onSettingsChange(settings.copy(torBridge = bridge)) },
                         )
+                    }
+                }
+
+                if (settings.torBridge == TorBridge.CUSTOM) {
+                    Divider()
+                    Column(Modifier.padding(15.dp)) {
+                        // What the user has, before what they can do about it.
+                        // A button above a field they have not filled in reads
+                        // as the only way to fill it, and pasting is the way
+                        // that works when the fetch cannot reach anything.
+                        Text(
+                            TorBridges.summarise(settings.torBridges)
+                                ?.let { stringResource(R.string.tor_bridges_have, it) }
+                                ?: stringResource(R.string.tor_bridges_none_yet),
+                            style = AetherTheme.type.Data,
+                            color = AetherTheme.colors.text2,
+                        )
+                        Spacer(Modifier.height(10.dp))
+                        PrimaryButton(
+                            text = if (bridgesFetching) {
+                                stringResource(R.string.tor_bridges_fetching)
+                            } else {
+                                stringResource(R.string.tor_bridges_fetch)
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("fetch-bridges-button"),
+                            enabled = !bridgesFetching,
+                            onClick = onFetchBridges,
+                        )
+                        bridgesMessage?.let {
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                it,
+                                style = AetherTheme.type.Data,
+                                color = AetherTheme.colors.signalFailed,
+                            )
+                        }
+                        Spacer(Modifier.height(12.dp))
+                        OutlinedTextField(
+                            value = bridgeText,
+                            onValueChange = {
+                                bridgeText = it
+                                onSettingsChange(settings.copy(torBridges = it))
+                            },
+                            label = { Text(stringResource(R.string.tor_bridges_field)) },
+                            placeholder = { Text(stringResource(R.string.tor_bridges_hint)) },
+                            textStyle = AetherTheme.type.Data.copy(color = AetherTheme.colors.text),
+                            minLines = 3,
+                            maxLines = 8,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("tor-bridges-field"),
+                            colors = TextFieldDefaults.colors(
+                                focusedContainerColor = AetherTheme.colors.ink1,
+                                unfocusedContainerColor = AetherTheme.colors.ink1,
+                            ),
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Note(stringResource(R.string.tor_bridges_where))
                     }
                 }
             }

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/WhiteAestherApp.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/WhiteAestherApp.kt
@@ -104,6 +104,9 @@ fun WhiteAestherApp(
     onTestEndpoint: (AppSettings) -> Unit,
     onResetEndpoint: (AppSettings) -> Unit,
     onCancelEndpointScan: () -> Unit,
+    onFetchBridges: () -> Unit = {},
+    bridgesFetching: Boolean = false,
+    bridgesMessage: String? = null,
     onRefreshChainNodes: () -> Unit = {},
     onSelectChainNode: (String) -> Unit = {},
     onTestChainNodes: () -> Unit = {},
@@ -239,6 +242,9 @@ fun WhiteAestherApp(
                     onGoToRoutingRules = {
                         openDetail(Destination.ROUTING_RULES, rulesFocus)
                     },
+                    onFetchBridges = onFetchBridges,
+                    bridgesFetching = bridgesFetching,
+                    bridgesMessage = bridgesMessage,
                     endpointModifier = Modifier.focusRequester(endpointFocus),
                     chainModifier = Modifier.focusRequester(chainFocus),
                     routingRulesModifier = Modifier.focusRequester(rulesFocus),

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -478,4 +478,16 @@
     <string name="tor_bridge_obfs4_detail">شکل ترافیک را پنهان می‌کند. از پل‌های عمومی استفاده می‌کند که خودشان زودتر از همه بسته می‌شوند.</string>
     <string name="tor_bridge_snowflake_detail">از طریق مرورگر داوطلبی که جواب بدهد. مقاوم است و سرعتش ثابت نیست.</string>
     <string name="tor_bridge_missing">این نسخه ترنسپورتی همراه ندارد، پس فقط حالت مستقیم اجرا می‌شود.</string>
+    <string name="tor_bridge_custom">پل‌هایی که به شما داده شده</string>
+    <string name="tor_bridge_custom_detail">پل‌هایی که یکی‌یکی توزیع می‌شوند نه منتشر. تنها نوعی که جایی که تور واقعاً بسته باشد شانس دارد.</string>
+    <string name="tor_bridges_field">خط‌های پل، هر کدام در یک سطر</string>
+    <string name="tor_bridges_hint">obfs4 1.2.3.4:443 FINGERPRINT cert=... iat-mode=0</string>
+    <string name="tor_bridges_fetch">گرفتن پل برای شبکهٔ من</string>
+    <string name="tor_bridges_fetching">در حال پرسیدن از تور…</string>
+    <string name="tor_bridges_fetched">%1$s پل گرفته شد</string>
+    <string name="tor_bridges_none_yet">هنوز پلی نیست. بگیریدشان، یا آنچه به شما داده شده را بچسبانید.</string>
+    <string name="tor_bridges_have">%1$s پل</string>
+    <string name="tor_bridges_failed">سرویس پل تور در دسترس نبود. اول با اتر یا سایفون وصل شوید، بعد دوباره امتحان کنید.</string>
+    <string name="tor_bridges_where">یا خودتان از bridges.torproject.org، ربات ‎@GetBridgesBot در تلگرام، یا ایمیل به bridges@torproject.org بگیرید.</string>
+    <string name="tor_bridges_none_recommended">تور برای %1$s پیشنهاد پلی ندارد. اینجا مستقیم یا پل‌های داخلی باید کار کند.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -484,4 +484,16 @@
     <string name="tor_bridge_obfs4_detail">Hides the shape of the traffic. Uses the public bridges, which are also the first ones blocked.</string>
     <string name="tor_bridge_snowflake_detail">Through whichever volunteer browser answers. Survives a lot, and varies in speed.</string>
     <string name="tor_bridge_missing">This build ships no pluggable transports, so only Direct can run.</string>
+    <string name="tor_bridge_custom">Bridges you were given</string>
+    <string name="tor_bridge_custom_detail">Bridges handed out one at a time rather than published. The only kind with a real chance where Tor is properly blocked.</string>
+    <string name="tor_bridges_field">Bridge lines, one per line</string>
+    <string name="tor_bridges_hint">obfs4 1.2.3.4:443 FINGERPRINT cert=... iat-mode=0</string>
+    <string name="tor_bridges_fetch">Fetch bridges for my network</string>
+    <string name="tor_bridges_fetching">Asking Tor…</string>
+    <string name="tor_bridges_fetched">Got %1$s bridges</string>
+    <string name="tor_bridges_none_yet">No bridges yet. Fetch them, or paste ones you were given.</string>
+    <string name="tor_bridges_have">%1$s bridges</string>
+    <string name="tor_bridges_failed">Could not reach Tor\'s bridge service. Connect with Aether or Psiphon first, then try again.</string>
+    <string name="tor_bridges_where">Or get them yourself from bridges.torproject.org, the @GetBridgesBot on Telegram, or by emailing bridges@torproject.org.</string>
+    <string name="tor_bridges_none_recommended">Tor has no bridge recommendation for %1$s. Direct or the built-in bridges should work here.</string>
 </resources>

--- a/app/src/test/java/com/whitedns/whiteaesther/core/TorBridgesTest.kt
+++ b/app/src/test/java/com/whitedns/whiteaesther/core/TorBridgesTest.kt
@@ -1,0 +1,150 @@
+package com.whitedns.whiteaesther.core
+
+import com.whitedns.whiteaesther.data.TorBridge
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Bridge lines as they actually arrive: pasted out of a Telegram reply, or
+ * fetched from Tor's recommendation service.
+ *
+ * The parsing is forgiving on purpose, and these say how far. Someone under a
+ * censored network, copying from a chat on a phone, is not going to produce a
+ * clean list -- and losing their bridges to a stray greeting line is a failure
+ * they cannot debug.
+ */
+class TorBridgesTest {
+    private val obfs4 =
+        "obfs4 37.218.245.14:38224 D9A82D2F9C2F65A18407B1D2B764F130847F8B5D cert=abc iat-mode=0"
+    private val snowflake =
+        "snowflake 192.0.2.3:80 2B280B23E1107BB62ABFC40DDCC8824814F80A72 fingerprint=2B28 url=https://x/"
+
+    @Test
+    fun aTelegramReplyKeepsItsBridgesAndLosesItsGreeting() {
+        val pasted = """
+            Here are your bridges:
+
+            $obfs4
+            $obfs4
+
+            Learn more at https://bridges.torproject.org
+        """.trimIndent()
+
+        val lines = TorBridges.parse(pasted)
+        assertEquals(2, lines.size)
+        assertTrue(lines.all { it.startsWith("obfs4 ") })
+    }
+
+    @Test
+    fun aCommentedLineIsNotABridge() {
+        assertTrue(TorBridges.parse("# $obfs4").isEmpty())
+    }
+
+    @Test
+    fun somethingThatIsNotABridgeIsDroppedRatherThanRefused() {
+        // The address is what separates a bridge from a sentence about bridges,
+        // and refusing the whole paste over one bad line is how a user loses
+        // the good ones.
+        val lines = TorBridges.parse("hello\n$obfs4\nnot a bridge at all\n")
+        assertEquals(listOf(obfs4), lines)
+    }
+
+    @Test
+    fun theTransportComesFromTheLineAndNotFromTheScreen() {
+        assertEquals("obfs4", TorBridges.transportOf(TorBridges.parse(obfs4)))
+        assertEquals("snowflake", TorBridges.transportOf(TorBridges.parse(snowflake)))
+        assertNull(TorBridges.transportOf(emptyList()))
+    }
+
+    @Test
+    fun aMixedPasteRunsOneTransportAndDropsTheOther() {
+        // One proxy runs at a time. Handing tor bridges for a transport that is
+        // not running fails as an unreachable bridge rather than as the mix-up
+        // it is, which is a much harder thing to be told.
+        val lines = TorBridges.parse("$obfs4\n$snowflake")
+        val transport = TorBridges.transportOf(lines)
+        assertEquals("obfs4", transport)
+        assertEquals(listOf(obfs4), TorBridges.forTransport(lines, transport!!))
+    }
+
+    @Test
+    fun eachTransportIsAskedOfTheBinaryThatImplementsIt() {
+        // Asking lyrebird for snowflake is a CMETHOD-ERROR and a bridge mode
+        // that never works.
+        assertEquals("libsnowflake.so", TorBridges.binaryFor("snowflake"))
+        assertEquals("liblyrebird.so", TorBridges.binaryFor("obfs4"))
+        assertEquals("liblyrebird.so", TorBridges.binaryFor("webtunnel"))
+        assertEquals("liblyrebird.so", TorBridges.binaryFor("meek_lite"))
+    }
+
+    @Test
+    fun theSummarySaysHowManyAndOfWhat() {
+        assertEquals("2 obfs4", TorBridges.summarise("$obfs4\n$obfs4"))
+        assertNull(TorBridges.summarise(""))
+        assertNull(TorBridges.summarise("just some words"))
+    }
+
+    @Test
+    fun customBridgesReachTheTorrcAndNothingElseDoes() {
+        val config = TorConfig.render(
+            TorBridge.CUSTOM,
+            null,
+            "127.0.0.1:9999",
+            customBridges = "$obfs4\n$snowflake",
+        )
+
+        assertTrue(config.contains("ClientTransportPlugin obfs4 socks5 127.0.0.1:9999"))
+        assertTrue(config.contains("Bridge $obfs4"))
+        // The snowflake line is for a proxy that is not running.
+        assertFalse(config.contains("Bridge snowflake"))
+    }
+
+    @Test
+    fun customWithNothingUsableIsRefusedRatherThanStartedBare() {
+        // The failure this prevents: no plugin line, no UseBridges, and a tor
+        // that connects directly under a screen that says it is behind a
+        // bridge -- on a network where direct is exactly what does not work.
+        assertEquals(TorConfig.Refusal.NO_BRIDGES, TorConfig.refusal(TorBridge.CUSTOM, ""))
+        assertEquals(
+            TorConfig.Refusal.NO_BRIDGES,
+            TorConfig.refusal(TorBridge.CUSTOM, "no bridges here"),
+        )
+        assertNull(TorConfig.refusal(TorBridge.CUSTOM, obfs4))
+        assertNull(TorConfig.refusal(TorBridge.OBFS4, ""))
+
+        val bare = TorConfig.render(TorBridge.CUSTOM, null, "127.0.0.1:9999", customBridges = "")
+        assertFalse(bare.contains("UseBridges"))
+        assertFalse(bare.contains("ClientTransportPlugin"))
+    }
+
+    @Test
+    fun torsRecommendationsAreReadInTheOrderTorGivesThem() {
+        // The order is the recommendation: Tor lists what to try first for that
+        // country, and the app can only run one transport at a time.
+        val body = """
+            {"settings":[
+              {"bridges":{"type":"webtunnel","source":"bridgedb","bridge_strings":["webtunnel [::1]:443 FP url=https://x/ ver=0.0.5"]}},
+              {"bridges":{"type":"snowflake","source":"bridgedb","bridge_strings":["$snowflake"]}},
+              {"bridges":{"type":"obfs4","source":"bridgedb","bridge_strings":["$obfs4"]}}
+            ]}
+        """.trimIndent()
+
+        val parsed = MoatClient.parse(body)
+        assertEquals(listOf("webtunnel", "snowflake", "obfs4"), parsed.map { it.transport })
+        assertEquals(1, parsed.first().lines.size)
+    }
+
+    @Test
+    fun anEmptyOrBrokenAnswerIsNoRecommendationRatherThanACrash() {
+        assertTrue(MoatClient.parse("""{"settings":[]}""").isEmpty())
+        assertTrue(MoatClient.parse("{}").isEmpty())
+        // A setting with a type and no lines is not something to select.
+        assertTrue(
+            MoatClient.parse("""{"settings":[{"bridges":{"type":"obfs4","bridge_strings":[]}}]}""")
+                .isEmpty(),
+        )
+    }
+}

--- a/app/src/test/java/com/whitedns/whiteaesther/core/TorConfigTest.kt
+++ b/app/src/test/java/com/whitedns/whiteaesther/core/TorConfigTest.kt
@@ -98,15 +98,23 @@ class TorConfigTest {
     }
 
     @Test
-    fun everyBridgeModeHasLinesAndDirectHasNone() {
+    fun everyBuiltInModeHasLinesAndTheOthersGetThemElsewhere() {
         assertTrue(TorConfig.bridgeLines(TorBridge.NONE).isEmpty())
-        TorBridge.entries.filter { it != TorBridge.NONE }.forEach { bridge ->
-            assertTrue("$bridge has no bridge line", TorConfig.bridgeLines(bridge).isNotEmpty())
-            assertTrue(
-                "$bridge line does not name its transport",
-                TorConfig.bridgeLines(bridge).all { it.startsWith(bridge.wireName) },
-            )
-        }
+        // CUSTOM has none of its own by definition: its lines are the ones the
+        // user pasted or the app fetched, and an empty list there is the state
+        // the screen exists to get them out of.
+        assertTrue(TorConfig.bridgeLines(TorBridge.CUSTOM).isEmpty())
+
+        TorBridge.entries
+            .filter { it != TorBridge.NONE && it != TorBridge.CUSTOM }
+            .forEach { bridge ->
+                val lines = TorConfig.bridgeLines(bridge)
+                assertTrue("$bridge has no bridge line", lines.isNotEmpty())
+                assertTrue(
+                    "$bridge line does not name its transport",
+                    lines.all { it.startsWith(bridge.wireName) },
+                )
+            }
     }
 
     @Test

--- a/native/tor/README.md
+++ b/native/tor/README.md
@@ -64,6 +64,37 @@ it never finishes bootstrapping: seven minutes on the public bridge, repeatedly,
 where obfs4 and snowflake took under a minute from the same network. The plumbing
 is generic, so it is a two-line change when there is a bridge worth pointing at.
 
+## Bridges
+
+Three sources, in increasing order of what they survive.
+
+**Built-in.** Tor's own published list, refreshed and health-checked by
+`refresh-bridges.ps1`. Public by design, and therefore the first addresses a
+censor blocks -- in the places this carrier matters most they are already gone.
+The first version of this list was written from memory and two of its three
+bridges had been dead long enough to be unreachable from an uncensored network,
+which is why the refresh script exists and prints reachability.
+
+**Pasted.** Whatever the user was given, from bridges.torproject.org, the
+`@GetBridgesBot` on Telegram, or email. Parsing is forgiving: a Telegram reply
+arrives with a greeting around it, and losing the bridges to a stray line is a
+failure the user cannot debug.
+
+**Fetched, in one tap.** `MoatClient` asks Tor's own recommendation service --
+the one Tor Browser's Connection Assist uses -- which answers with the transports
+it currently recommends for a country, each with lines from BridgeDB rather than
+from the public list. No CAPTCHA.
+
+Two things make that work here that do not work in a browser. The country asked
+about is the *network's*, from the telephony operator, not the exit's: asked
+through a tunnel the service would otherwise be told about Singapore and answer
+about Singapore. And the request itself goes through whichever carrier is
+already running, because bridges.torproject.org is blocked in most of the places
+its answer is wanted -- which is something this app has and Tor Browser does not.
+
+Measured for Iran: the service recommends webtunnel, and a session behind it
+built a circuit in seventeen seconds.
+
 ## Bootstrapped is not the same as listening
 
 `TorService` broadcasts `STATUS_ON` when tor's control connection comes up, which

--- a/native/tor/refresh-bridges.ps1
+++ b/native/tor/refresh-bridges.ps1
@@ -1,0 +1,51 @@
+# Refreshes the built-in bridge lines from Tor's own service.
+#
+#   pwsh -File native/tor/refresh-bridges.ps1
+#
+# Prints the lines to paste into TorConfig.kt, and says which of them answer
+# from this machine. It does not edit the source: what goes in the app is a
+# decision, and a script that silently rewrote a constant would make it a
+# side effect of running a script.
+#
+# Why this exists: the list that shipped first was written from memory and two
+# of its three bridges had been gone long enough to be unreachable from an
+# uncensored network. A list of addresses rots, and there has to be a way to
+# tell that it has.
+
+$ErrorActionPreference = 'Stop'
+
+$body = '{"country":""}'
+Write-Host "asking Tor for its current built-in bridges..." -ForegroundColor Cyan
+$response = Invoke-RestMethod -Uri 'https://bridges.torproject.org/moat/circumvention/builtin' `
+    -Method Post -ContentType 'application/vnd.api+json' -Body $body
+
+foreach ($transport in $response.PSObject.Properties) {
+    $lines = $transport.Value
+    if (-not $lines) { continue }
+    Write-Host ""
+    Write-Host "$($transport.Name):" -ForegroundColor Green
+    foreach ($line in $lines) {
+        $address = ($line -split ' ')[1]
+        $host_, $port = $address -split ':', 2
+        # Snowflake and meek advertise placeholder addresses -- 192.0.2.x is
+        # the documentation range -- because the real endpoint is a CDN or a
+        # volunteer browser. Reachability means nothing for those.
+        $reachable = if ($host_ -like '192.0.2.*') {
+            'n/a'
+        } else {
+            try {
+                $client = [System.Net.Sockets.TcpClient]::new()
+                $ok = $client.ConnectAsync($host_, [int]$port).Wait(8000)
+                $client.Close()
+                if ($ok) { 'up' } else { 'DEAD' }
+            } catch { 'DEAD' }
+        }
+        Write-Host ("  [{0,-4}] {1}" -f $reachable, $line)
+    }
+}
+
+Write-Host ""
+Write-Host "Anything marked DEAD should not ship. Built-ins are public and are" -ForegroundColor Yellow
+Write-Host "blocked first wherever they matter -- they are a fallback, and the" -ForegroundColor Yellow
+Write-Host "answer for a censored network is the in-app fetch or a bridge the" -ForegroundColor Yellow
+Write-Host "user was given." -ForegroundColor Yellow


### PR DESCRIPTION
Reported: obfs4 does not connect from Iran.

## What was actually wrong

Two of the three built-in obfs4 bridges were unreachable **from an uncensored
network** — the list was written from memory and had rotted. obfs4 had one working
bridge everywhere, and in Iran that one is blocked, which leaves nothing.

`native/tor/refresh-bridges.ps1` now takes the list from Tor's own service and prints
which addresses answer. The six that ship were checked that way; the one Tor lists as
dead was left out.

## But that does not fix Iran

Built-in bridges are published, so a censor has them the same day everyone else does.
What works there is a bridge handed out one at a time — which until now meant telling
the user to visit a blocked website.

**One tap.** `MoatClient` asks Tor's own recommendation service (the one Tor Browser's
Connection Assist uses): per-country, lines from BridgeDB rather than the public list,
no CAPTCHA.

Two things make it work here that do not work in a browser:

- The country asked about is the **network's**, from the telephony operator, not the
  exit's. Asked through a tunnel the service would be told about Singapore and answer
  about Singapore.
- The request goes through **whichever carrier is already running**. `bridges.torproject.org`
  is blocked in most of the places its answer is wanted, and this app has two other ways
  out of exactly those places.

Pasting uses the same field — a line from `@GetBridgesBot` and a line from Tor's service
are the same thing. Parsing is forgiving, because a paste arrives with a greeting around it.

An empty answer is not a failure: Tor recommends nothing for an uncensored country, and
the screen says so instead of reporting a fault.

## Verified

Live, on an emulator, asking as Iran: **webtunnel** recommended, circuit built in 17
seconds, exit `192.42.116.66` — through a transport that is not in the built-in list at all.

84 instrumentation tests; the two failures are pre-existing on `main`. Unit tests and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)