### PR TITLE
Ask Tor about the right country, and stop painting its answer red

### DIFF
--- a/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -265,10 +266,11 @@ class MainActivity : ComponentActivity() {
                     onScanEndpoints = viewModel::scanEndpoints,
                     onTestEndpoint = viewModel::testEndpoint,
                     onResetEndpoint = viewModel::resetEndpoint,
-                    onFetchBridges = { viewModel.fetchBridges(settings) },
+                    onFetchBridges = { country -> viewModel.fetchBridges(settings, country) },
                     bridgesFetching = viewModel.bridgesFetching.collectAsStateWithLifecycle().value,
                     bridgesMessage = viewModel.bridgesMessage.collectAsStateWithLifecycle().value,
                     psiphonRegions = viewModel.psiphonRegions.collectAsStateWithLifecycle().value,
+                    detectedCountry = remember { viewModel.detectedCountry() },
                     onCancelEndpointScan = viewModel::cancelEndpointScan,
                     onRefreshChainNodes = { viewModel.refreshChainNodes(settings) },
                     onSelectChainNode = { node -> viewModel.selectChainNode(settings, node) },

--- a/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/MainViewModel.kt
@@ -40,6 +40,14 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+/**
+ * Something the bridge fetch has to say, and whether it is a fault.
+ *
+ * Tor answering "nothing recommended here" is not a failure and must not be
+ * dressed as one; failing to reach Tor at all is.
+ */
+data class BridgeMessage(val text: String, val isError: Boolean)
+
 /** Something to tell the user about their identity, after an export or import. */
 data class IdentityMessage(val text: String, val isError: Boolean = false)
 
@@ -143,8 +151,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val mutableBridgesFetching = MutableStateFlow(false)
     val bridgesFetching = mutableBridgesFetching.asStateFlow()
 
-    /** Why the last bridge fetch failed, or null. */
-    private val mutableBridgesMessage = MutableStateFlow<String?>(null)
+    /**
+     * What the last bridge fetch had to say, and whether it went wrong.
+     *
+     * The two are separate because they read differently. "Tor recommends
+     * nothing for your country" is Tor saying this network needs no help, which
+     * is true of most of the world; painting that red tells the user something
+     * broke when nothing did.
+     */
+    private val mutableBridgesMessage = MutableStateFlow<BridgeMessage?>(null)
     val bridgesMessage = mutableBridgesMessage.asStateFlow()
 
     /**
@@ -591,7 +606,17 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
      * service would otherwise be told about Singapore and answer about
      * Singapore, which is useless to somebody in Iran.
      */
-    fun fetchBridges(settings: AppSettings) {
+    /**
+     * The country the fetch will ask about unless told otherwise.
+     *
+     * Shown so it can be corrected. It comes from the network operator, which
+     * is right for somebody at home and wrong for somebody testing for a place
+     * they are not -- and Tor answers per country, so asking as the wrong one
+     * gets a correct answer to the wrong question.
+     */
+    fun detectedCountry(): String = MoatClient.country(getApplication())
+
+    fun fetchBridges(settings: AppSettings, country: String = "") {
         if (bridgeJob?.isActive == true) return
         mutableBridgesMessage.value = null
         mutableBridgesFetching.value = true
@@ -600,13 +625,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             val through = EngineStatusStore.status.value
                 .takeIf { it.stage == EngineStage.CONNECTED }
                 ?.carrierSocksPort
-            val country = MoatClient.country(context)
-            val result = MoatClient.recommendations(country, through)
+            val asked = country.trim().lowercase().takeIf { it.length == 2 }
+                ?: MoatClient.country(context)
+            val result = MoatClient.recommendations(asked, through)
             mutableBridgesFetching.value = false
 
             val recommendations = result.getOrElse { error ->
                 EngineLog.record(LogLevel.WARN, "bridges", error.message ?: "fetch failed")
-                mutableBridgesMessage.value = say(R.string.tor_bridges_failed)
+                mutableBridgesMessage.value =
+                    BridgeMessage(say(R.string.tor_bridges_failed), isError = true)
                 return@launch
             }
             // The first one Tor lists, because it lists them in the order it
@@ -617,13 +644,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             // true of most of the world and is not a fault to report as one.
             val best = recommendations.firstOrNull { it.lines.isNotEmpty() }
             if (best == null) {
-                mutableBridgesMessage.value = say(R.string.tor_bridges_none_recommended, country.uppercase())
+                mutableBridgesMessage.value = BridgeMessage(
+                    say(R.string.tor_bridges_none_recommended, asked.uppercase()),
+                    isError = false,
+                )
                 return@launch
             }
             EngineLog.record(
                 LogLevel.INFO,
                 "bridges",
-                "tor recommends ${best.transport} for $country: ${best.lines.size} bridges",
+                "tor recommends ${best.transport} for $asked: ${best.lines.size} bridges",
             )
             save(
                 settings.copy(

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/Screens.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.whitedns.whiteaesther.AddressPair
 import com.whitedns.whiteaesther.EndpointOperation
+import com.whitedns.whiteaesther.BridgeMessage
 import com.whitedns.whiteaesther.EndpointScannerState
 import com.whitedns.whiteaesther.IdentityMessage
 import com.whitedns.whiteaesther.R
@@ -664,9 +665,10 @@ fun RoutesScreen(
     onGoToEndpoint: () -> Unit,
     onGoToChain: () -> Unit = {},
     onGoToRoutingRules: () -> Unit = {},
-    onFetchBridges: () -> Unit = {},
+    onFetchBridges: (String) -> Unit = {},
     bridgesFetching: Boolean = false,
-    bridgesMessage: String? = null,
+    bridgesMessage: BridgeMessage? = null,
+    detectedCountry: String = "",
     psiphonRegions: List<String> = emptyList(),
     endpointModifier: Modifier = Modifier,
     chainModifier: Modifier = Modifier,
@@ -681,6 +683,9 @@ fun RoutesScreen(
     // Read from the composition so a language change redraws the country names
     // with it, which Locale.getDefault() would not.
     val uiLocale = LocalConfiguration.current.locales[0]
+    var bridgeCountry by rememberSaveable(detectedCountry) {
+        mutableStateOf(detectedCountry.uppercase())
+    }
 
     ScreenColumn {
         CrumbBar(stringResource(R.string.routes))
@@ -863,14 +868,43 @@ fun RoutesScreen(
                                 .fillMaxWidth()
                                 .testTag("fetch-bridges-button"),
                             enabled = !bridgesFetching,
-                            onClick = onFetchBridges,
+                            onClick = { onFetchBridges(bridgeCountry) },
                         )
-                        bridgesMessage?.let {
+                        Spacer(Modifier.height(8.dp))
+                        // Shown so it can be corrected. The country comes from
+                        // the network operator, which is right for somebody at
+                        // home and wrong for somebody asking on behalf of a
+                        // place they are not -- and Tor answers per country, so
+                        // asking as the wrong one gets a correct answer to the
+                        // wrong question.
+                        OutlinedTextField(
+                            value = bridgeCountry,
+                            onValueChange = { bridgeCountry = it.take(2).uppercase() },
+                            label = { Text(stringResource(R.string.tor_bridges_country)) },
+                            singleLine = true,
+                            textStyle = AetherTheme.type.Data.copy(color = AetherTheme.colors.text),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("bridge-country-field"),
+                            colors = TextFieldDefaults.colors(
+                                focusedContainerColor = AetherTheme.colors.ink1,
+                                unfocusedContainerColor = AetherTheme.colors.ink1,
+                            ),
+                        )
+                        bridgesMessage?.let { message ->
                             Spacer(Modifier.height(8.dp))
                             Text(
-                                it,
+                                message.text,
                                 style = AetherTheme.type.Data,
-                                color = AetherTheme.colors.signalFailed,
+                                // Red is for a fault. Tor having no
+                                // recommendation for a country is Tor saying
+                                // the network needs no help, which is true of
+                                // most of the world.
+                                color = if (message.isError) {
+                                    AetherTheme.colors.signalFailed
+                                } else {
+                                    AetherTheme.colors.text2
+                                },
                             )
                         }
                         Spacer(Modifier.height(12.dp))

--- a/app/src/main/java/com/whitedns/whiteaesther/ui/WhiteAestherApp.kt
+++ b/app/src/main/java/com/whitedns/whiteaesther/ui/WhiteAestherApp.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.whitedns.whiteaesther.AddressPair
 import com.whitedns.whiteaesther.ChainState
+import com.whitedns.whiteaesther.BridgeMessage
 import com.whitedns.whiteaesther.EndpointScannerState
 import com.whitedns.whiteaesther.IdentityMessage
 import com.whitedns.whiteaesther.R
@@ -104,9 +105,10 @@ fun WhiteAestherApp(
     onTestEndpoint: (AppSettings) -> Unit,
     onResetEndpoint: (AppSettings) -> Unit,
     onCancelEndpointScan: () -> Unit,
-    onFetchBridges: () -> Unit = {},
+    onFetchBridges: (String) -> Unit = {},
     bridgesFetching: Boolean = false,
-    bridgesMessage: String? = null,
+    bridgesMessage: BridgeMessage? = null,
+    detectedCountry: String = "",
     psiphonRegions: List<String> = emptyList(),
     onRefreshChainNodes: () -> Unit = {},
     onSelectChainNode: (String) -> Unit = {},
@@ -246,6 +248,7 @@ fun WhiteAestherApp(
                     onFetchBridges = onFetchBridges,
                     bridgesFetching = bridgesFetching,
                     bridgesMessage = bridgesMessage,
+                    detectedCountry = detectedCountry,
                     psiphonRegions = psiphonRegions,
                     endpointModifier = Modifier.focusRequester(endpointFocus),
                     chainModifier = Modifier.focusRequester(chainFocus),

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -499,4 +499,5 @@
     <string name="off_traffic_leaves_from_carrier">خاموش. ترافیک از %1$s خارج می‌شود</string>
     <string name="on_dialled_through_carrier">روشن، از داخل %1$s شماره‌گیری می‌شود</string>
     <string name="nodes_dialled_through_carrier">نودهای شما از داخل %1$s شماره‌گیری می‌شوند. یک راه خروج دارد و نودها از همان می‌روند، پس اینجا چیزی برای انتخاب نیست.</string>
+    <string name="tor_bridges_country">به‌عنوان این کشور بپرس</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,4 +505,5 @@
     <string name="off_traffic_leaves_from_carrier">Off. Traffic leaves from %1$s</string>
     <string name="on_dialled_through_carrier">On, dialled through %1$s</string>
     <string name="nodes_dialled_through_carrier">Your nodes are dialled through %1$s. It has one way out and they take it, so there is nothing to choose here.</string>
+    <string name="tor_bridges_country">Ask as this country</string>
 </resources>


### PR DESCRIPTION
Two things the bridge-fetch screen was getting wrong, both reported from a device.

**The country.** It is read from the network operator — right for somebody at home,
wrong for anyone asking on behalf of a place they are not. The answer is per country,
so asking as the wrong one gets a correct answer to the wrong question. It is shown
now, and editable.

**The colour.** *"Tor has no bridge recommendation for TH"* was drawn in the failure
colour. It is not a failure — it is Tor saying this network needs no help, which is
true of most of the world. The message carries its own severity now, and only a fault
is red.

## Verified

On an **Android 17 emulator with 16 KB pages**, which is what a current phone has:
the app runs, 85 instrumentation tests (the two failures are pre-existing on `main`),
and all five live Psiphon tests pass there — including the exit-country one, with
Psiphon reporting its 25 regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)